### PR TITLE
refactor: use toString(), remove paste0 in stop, use dplyr::between

### DIFF
--- a/R/check_supported_type.R
+++ b/R/check_supported_type.R
@@ -15,6 +15,6 @@ check_supported_type <- function(type) {
   supported_types <- list_supported_types()
   if (!any(type %in% supported_types$type)) {
     stop("Unsupported type specified. Choose one of the following: ",
-         paste(supported_types$type, collapse = ", "))
+         toString(supported_types$type))
   }
 }

--- a/R/create_summary_statistics.R
+++ b/R/create_summary_statistics.R
@@ -52,8 +52,9 @@ create_summary_statistics <- function(
     sapply(class)
 
   if(sum(col_types %in% c("numeric", "integer", "logical")) < length(col_types)) {
-    stop(paste0("The following columns are neither numeric nor integer: ",
-                paste(names(col_types[!col_types %in% c("numeric", "integer", "logical")]), collapse = ", ")))
+    stop("The following columns are neither numeric nor integer: ",
+         toString(names(col_types[!col_types %in% c("numeric", "integer", "logical")]))
+    )
   }
 
   # Determine set of summary statistics to compute

--- a/R/download_data_factors.R
+++ b/R/download_data_factors.R
@@ -74,6 +74,9 @@ download_data_factors_ff <- function(type, start_date, end_date) {
 
   download_french_data <- getNamespace("frenchdata")$download_french_data
 
+  start_date <- as.Date(start_date)
+  end_date <- as.Date(end_date)
+
   factors_ff_types <- list_supported_types_ff()
   dataset <- factors_ff_types$dataset_name[factors_ff_types$type == type]
 
@@ -91,10 +94,10 @@ download_data_factors_ff <- function(type, start_date, end_date) {
   processed_data <- processed_data |>
     mutate(
       across(-date, ~na_if(.,-99.99)),
-      across(-date, ~ . / 100),
+      across(-date, ~ . / 100)
     ) |>
     rename_with(tolower) |>
-    filter(date >= start_date & date <= end_date)
+    filter(between(date, start_date, end_date))
 
   processed_data <- if (grepl("industry", type, fixed = TRUE)) {
     processed_data |>
@@ -143,6 +146,8 @@ download_data_factors_q <- function(
 ) {
 
   check_supported_type(type)
+  start_date <- as.Date(start_date)
+  end_date <- as.Date(end_date)
 
   factors_q_types <- list_supported_types_q()
   dataset <- factors_q_types$dataset_name[factors_q_types$type == type]
@@ -162,7 +167,7 @@ download_data_factors_q <- function(
     rename_with(~sub("R_", "", ., fixed = TRUE)) |>
     rename_with(tolower) |>
     mutate(across(-date, ~. / 100)) |>
-    filter(date >= start_date & date <= end_date) |>
+    filter(between(date, start_date, end_date)) |>
     select(date, risk_free = f, mkt_excess = mkt, everything())
 
   processed_data

--- a/R/download_data_wrds_clean_trace.R
+++ b/R/download_data_wrds_clean_trace.R
@@ -34,8 +34,10 @@ download_data_wrds_clean_trace <- function(cusips, start_date, end_date) {
   trace_enhanced_db <- tbl(con, in_schema("trace", "trace_enhanced"))
 
   trace_all <- trace_enhanced_db |>
-    filter(cusip_id %in% cusips) |>
-    filter(trd_exctn_dt >= start_date & trd_exctn_dt <= end_date) |>
+    filter(
+      cusip_id %in% cusips,
+      between(trd_exctn_dt, start_date, end_date)
+    ) |>
     select(cusip_id, msg_seq_nb, orig_msg_seq_nb,
            entrd_vol_qt, rptd_pr, yld_pt, rpt_side_cd, cntra_mp_id,
            trd_exctn_dt, trd_exctn_tm, trd_rpt_dt, trd_rpt_tm,

--- a/R/download_data_wrds_compustat.R
+++ b/R/download_data_wrds_compustat.R
@@ -34,6 +34,9 @@ download_data_wrds_compustat <- function(type, start_date, end_date, ...) {
 
   con <- get_wrds_connection()
 
+  start_date <- as.Date(start_date)
+  end_date <- as.Date(end_date)
+
   if (grepl("compustat_annual", type, fixed = TRUE)) {
     funda_db <- tbl(con, in_schema("comp", "funda"))
 
@@ -42,7 +45,7 @@ download_data_wrds_compustat <- function(type, start_date, end_date, ...) {
         indfmt == "INDL" &
           datafmt == "STD" &
           consol == "C" &
-          datadate >= start_date & datadate <= end_date
+          between(datadate, start_date, end_date)
       ) |>
       select(
         gvkey, datadate, seq, ceq, at, lt, txditc,

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -37,6 +37,8 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
   if (!(version %in% c("v1", "v2"))) stop("Parameter version must be equal to v1 or v2.")
 
   check_if_package_installed("dbplyr", type)
+  start_date <- as.Date(start_date)
+  end_date <- as.Date(end_date)
 
   in_schema <- getNamespace("dbplyr")$in_schema
 
@@ -51,14 +53,14 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
       msedelist_db <- tbl(con, in_schema("crsp", "msedelist"))
 
       crsp_monthly <- msf_db |>
-        filter(date >= start_date & date <= end_date) |>
+        filter(between(date, start_date, end_date)) |>
         inner_join(
           msenames_db |>
             filter(shrcd %in% c(10, 11)) |>
             select(permno, exchcd, siccd, namedt, nameendt),
           join_by(permno)
         ) |>
-        filter(date >= namedt & date <= nameendt) |>
+        filter(between(date, namedt, nameendt)) |>
         mutate(month = floor_date(date, "month")) |>
         left_join(
           msedelist_db |>
@@ -151,7 +153,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
       stksecurityinfohist_db <- tbl(con, in_schema("crsp", "stksecurityinfohist"))
 
       crsp_monthly <- msf_db |>
-        filter(mthcaldt >= start_date & mthcaldt <= end_date) |>
+        filter(between(mthcaldt, start_date, end_date)) |>
         select(-c(siccd, primaryexch, conditionaltype, tradingstatusflg)) |>
         inner_join(
           stksecurityinfohist_db |>
@@ -167,7 +169,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
                    primaryexch, siccd),
           join_by(permno)
         )  |>
-        filter(mthcaldt >= secinfostartdt & mthcaldt <= secinfoenddt) |>
+        filter(between(mthcaldt, secinfostartdt, secinfoenddt)) |>
         mutate(month = floor_date(mthcaldt, "month")) |>
         select(
           permno,
@@ -250,7 +252,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
     if (version == "v1") {
 
       dsf_db <- tbl(con, in_schema("crsp", "dsf")) |>
-        filter(date >= start_date & date <= end_date)
+        filter(between(date, start_date, end_date))
       msenames_db <- tbl(con, in_schema("crsp", "msenames"))
       msedelist_db <- tbl(con, in_schema("crsp", "msedelist"))
 
@@ -341,8 +343,10 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
         ]
 
         crsp_daily_sub <- dsf_db |>
-          filter(permno %in% permno_batch) |>
-          filter(dlycaldt >= start_date & dlycaldt <= end_date) |>
+          filter(
+            permno %in% permno_batch,
+            between(dlycaldt, start_date, end_date)
+          ) |>
           inner_join(
             stksecurityinfohist_db |>
               filter(sharetype == "NS" &
@@ -356,7 +360,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
               select(permno, secinfostartdt, secinfoenddt),
             join_by(permno)
           ) |>
-          filter(dlycaldt >= secinfostartdt & dlycaldt <= secinfoenddt)  |>
+          filter(between(dlycaldt, secinfostartdt, secinfoenddt))  |>
           select(permno, date = dlycaldt, ret = dlyret) |>
           collect() |>
           drop_na()

--- a/R/estimate_model.R
+++ b/R/estimate_model.R
@@ -56,7 +56,7 @@ estimate_model <- function(data, model, min_obs = 1) {
     if (!all(independent_vars %in% names(data))) {
       missing_vars <- independent_vars[!independent_vars %in% names(data)]
       stop("The following independent variables are missing in the data: ",
-           paste(missing_vars, collapse=", "), ".")
+           toString(missing_vars), ".")
     }
 
     fit <- stats::lm(stats::as.formula(model), data = data)

--- a/R/global_variables.R
+++ b/R/global_variables.R
@@ -28,6 +28,7 @@ utils::globalVariables(
     "rptd_pr", "entrd_vol_qt", "yld_pt", "rpt_side_cd", "cntra_mp_id",
     "asof_cd", "days_to_sttl_ct", "days_to_sttl_ct2", "msg_seq_nb", "orig_msg_seq_nb",
     "pr_trd_dt", "spcl_trd_fl", "stlmnt_dt", "trc_st", "trd_rpt_dt", "trd_rpt_tm", "wis_fl",
-    "conditionaltype", "tradingstatusflg"
+    "conditionaltype", "tradingstatusflg",
+    "log_d12", "log_e12"
   )
 )


### PR DESCRIPTION
- Use `toString(x)` instead of `paste(x, collapse = ", ")`
- Use `dplyr::between()` and coerce date inputs to date
- Remove unneeded `paste0()` from `stop()`
- Only compute new col in tibble once and reuse
- Use `on.exit()` for temporary file clean-up