### PR TITLE
29 crsp daily add support for columns in msenames v1 and stksecurityinfohist v2

### DIFF
--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -336,7 +336,8 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
 
     } else {
 
-      dsf_db <- tbl(con, in_schema("crsp", "dsf_v2"))
+      dsf_db <- tbl(con, in_schema("crsp", "dsf_v2")) |>
+        filter(between(dlycaldt, start_date, end_date))
       stksecurityinfohist_db <- tbl(con, in_schema("crsp", "stksecurityinfohist"))
 
       dsf_db_columns <- c("permno", colnames(dsf_db)[-which(colnames(dsf_db) %in% colnames(stksecurityinfohist_db))])
@@ -360,10 +361,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
         ]
 
         crsp_daily_sub <- dsf_db |>
-          filter(
-            permno %in% permno_batch,
-            between(dlycaldt, start_date, end_date)
-          ) |>
+          filter(permno %in% permno_batch) |>
           select(all_of(dsf_db_columns)) |>
           inner_join(
             stksecurityinfohist_db |>

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -281,6 +281,12 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
 
         crsp_daily_sub <- dsf_db |>
           filter(permno %in% permno_batch) |>
+          inner_join(
+            msenames_db |>
+              filter(shrcd %in% c(10, 11)),
+            join_by(permno)
+          ) |>
+          filter(between(date, namedt, nameendt)) |>
           select(permno, date, ret, additional_columns) |>
           collect() |>
           drop_na()

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -289,7 +289,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
           filter(between(date, namedt, nameendt)) |>
           select(permno, date, ret, additional_columns) |>
           collect() |>
-          drop_na()
+          drop_na(permno, date, ret)
 
         if (nrow(crsp_daily_sub) > 0) {
 
@@ -372,7 +372,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
           filter(between(dlycaldt, secinfostartdt, secinfoenddt))  |>
           select(permno, date = dlycaldt, ret = dlyret, additional_columns) |>
           collect() |>
-          drop_na()
+          drop_na(permno, date, ret)
 
         if (nrow(crsp_daily_sub) > 0) {
 

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -366,8 +366,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
                        issuertype %in% c("ACOR", "CORP") &
                        primaryexch %in% c("N", "A", "Q") &
                        conditionaltype %in% c("RW", "NW") &
-                       tradingstatusflg == "A") |>
-              select(permno, secinfostartdt, secinfoenddt),
+                       tradingstatusflg == "A"),
             join_by(permno)
           ) |>
           filter(between(dlycaldt, secinfostartdt, secinfoenddt))  |>

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -78,7 +78,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
         select(
           permno, date, month, ret, shrout, altprc,
           exchcd, siccd, dlret, dlstcd,
-          additional_columns
+          all_of(additional_columns)
         ) |>
         collect() |>
         mutate(
@@ -187,7 +187,7 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
           prc = mthprc,
           primaryexch,
           siccd,
-          additional_columns
+          all_of(additional_columns)
         ) |>
         collect() |>
         mutate(
@@ -292,7 +292,8 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
             join_by(permno)
           ) |>
           filter(between(date, namedt, nameendt)) |>
-          select(permno, date, ret, additional_columns) |>
+          select(permno, date, ret,
+                 all_of(additional_columns)) |>
           collect() |>
           drop_na(permno, date, ret)
 
@@ -376,7 +377,8 @@ download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500
             join_by(permno)
           ) |>
           filter(between(dlycaldt, secinfostartdt, secinfoenddt))  |>
-          select(permno, date = dlycaldt, ret = dlyret, additional_columns) |>
+          select(permno, date = dlycaldt, ret = dlyret,
+                 all_of(additional_columns)) |>
           collect() |>
           drop_na(permno, date, ret)
 


### PR DESCRIPTION
Changes:

- Additional historical data can be added in daily CRSP
- We now consistently pick variables in their historically accurate form and never select the variables that might be back-filled (the new variable that is assigned is cumbersome, but cleaner than alternatives)
- Fixed a tidyselect >1.1.0 warning message induced with `additional_columns` by wrapping it in `all_of(.)`
- For daily CRSP v2 we now filter the time series before pulling the available permnos (as we did in v1 already)