### PR TITLE
Make start_date and end_date optional in `download_data() `

### DIFF
--- a/R/download_data.R
+++ b/R/download_data.R
@@ -8,9 +8,12 @@
 #'
 #' @param type The type of dataset to download, indicating either factor data or
 #'   macroeconomic predictors.
-#' @param start_date The start date for filtering the data, in "YYYY-MM-DD"
-#'   format.
-#' @param end_date The end date for filtering the data, in "YYYY-MM-DD" format.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, the full dataset or a subset is returned,
+#'   dependening on the dataset type.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, the full dataset or a subset is returned,
+#'   depending on the dataset type.
 #'
 #' @return A tibble with processed data, including dates and the relevant
 #'   financial metrics, filtered by the specified date range.
@@ -22,7 +25,7 @@
 #' }
 #'
 #' @export
-download_data <- function(type, start_date, end_date) {
+download_data <- function(type, start_date = NULL, end_date = NULL) {
 
   check_supported_type(type)
 

--- a/R/download_data_factors.R
+++ b/R/download_data_factors.R
@@ -23,7 +23,9 @@
 #' }
 #'
 #' @export
-download_data_factors <- function(type, start_date, end_date) {
+download_data_factors <- function(
+    type, start_date = NULL, end_date = NULL
+  ) {
 
   check_supported_type(type)
 
@@ -53,9 +55,10 @@ download_data_factors <- function(type, start_date, end_date) {
 #'
 #' @param type The type of dataset to download, corresponding to the specific
 #'   Fama-French model and frequency.
-#' @param start_date The start date for filtering the data, in "YYYY-MM-DD"
-#'   format.
-#' @param end_date The end date for filtering the data, in "YYYY-MM-DD" format.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, the full dataset is returned.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, the full dataset is returned.
 #'
 #' @return A tibble with processed factor data, including the date, risk-free
 #'   rate, market excess return, and other factors, filtered by the specified
@@ -71,16 +74,21 @@ download_data_factors <- function(type, start_date, end_date) {
 #' @importFrom lubridate ymd floor_date
 #'
 #' @export
-download_data_factors_ff <- function(type, start_date, end_date) {
+download_data_factors_ff <- function(
+    type, start_date = NULL, end_date = NULL
+  ) {
 
   check_supported_type(type)
 
   check_if_package_installed("frenchdata", type)
-
   download_french_data <- getNamespace("frenchdata")$download_french_data
 
-  start_date <- as.Date(start_date)
-  end_date <- as.Date(end_date)
+  if (is.null(start_date) || is.null(end_date)) {
+    message("No start_date or end_date provided. Returning the full data set.")
+  } else {
+    start_date <- as.Date(start_date)
+    end_date <- as.Date(end_date)
+  }
 
   factors_ff_types <- list_supported_types_ff()
   dataset <- factors_ff_types$dataset_name[factors_ff_types$type == type]
@@ -104,8 +112,7 @@ download_data_factors_ff <- function(type, start_date, end_date) {
       across(-date, ~na_if(.,-99.99)),
       across(-date, ~na_if(., -999)),
       across(-date, ~ . / 100)
-    ) |>
-    filter(between(date, start_date, end_date))
+    )
 
   # Clean column names
   colnames_clean <- colnames(processed_data) |>
@@ -114,6 +121,11 @@ download_data_factors_ff <- function(type, start_date, end_date) {
     gsub("rf", "risk_free", x = _)
 
   colnames(processed_data) <- colnames_clean
+
+  if (!is.null(start_date) && !is.null(end_date)) {
+    processed_data <- processed_data |>
+      filter(between(date, start_date, end_date))
+  }
 
   processed_data
 }
@@ -129,9 +141,10 @@ download_data_factors_ff <- function(type, start_date, end_date) {
 #'
 #' @param type The type of dataset to download (e.g., "factors_q5_daily",
 #'   "factors_q5_monthly").
-#' @param start_date The start date for filtering the data, in "YYYY-MM-DD"
-#'   format.
-#' @param end_date The end date for filtering the data, in "YYYY-MM-DD" format.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, the full dataset is returned.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, the full dataset is returned.
 #' @param url The base URL from which to download the dataset files, with a
 #'   specific path for Global Q datasets.
 #'
@@ -150,12 +163,17 @@ download_data_factors_ff <- function(type, start_date, end_date) {
 #'
 #' @export
 download_data_factors_q <- function(
-    type, start_date, end_date, url = "http://global-q.org/uploads/1/2/2/6/122679606/"
+    type, start_date = NULL, end_date = NULL, url = "http://global-q.org/uploads/1/2/2/6/122679606/"
 ) {
 
   check_supported_type(type)
-  start_date <- as.Date(start_date)
-  end_date <- as.Date(end_date)
+
+  if (is.null(start_date) || is.null(end_date)) {
+    message("No start_date or end_date provided. Returning the full data set.")
+  } else {
+    start_date <- as.Date(start_date)
+    end_date <- as.Date(end_date)
+  }
 
   factors_q_types <- list_supported_types_q()
   dataset <- factors_q_types$dataset_name[factors_q_types$type == type]
@@ -175,8 +193,12 @@ download_data_factors_q <- function(
     rename_with(~sub("R_", "", ., fixed = TRUE)) |>
     rename_with(tolower) |>
     mutate(across(-date, ~. / 100)) |>
-    filter(between(date, start_date, end_date)) |>
     select(date, risk_free = f, mkt_excess = mkt, everything())
+
+  if (!is.null(start_date) && !is.null(end_date)) {
+    processed_data <- processed_data |>
+      filter(between(date, start_date, end_date))
+  }
 
   processed_data
 }

--- a/R/download_data_wrds.R
+++ b/R/download_data_wrds.R
@@ -9,10 +9,10 @@
 #'   one of the predefined patterns to indicate the dataset: "wrds_crsp" for
 #'   CRSP data, "wrds_compustat" for Compustat data, or "wrds_ccm_links" for CCM
 #'   links data.
-#' @param start_date A date in 'YYYY-MM-DD' format indicating the start of the
-#'   period for which data is requested.
-#' @param end_date A date in 'YYYY-MM-DD' format indicating the end of the
-#'   period for which data is requested.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, a subset of the dataset is returned.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, a subste of the dataset is returned.
 #'
 #' @return A data frame containing the requested data, with the structure and
 #'   contents depending on the specified `type`.
@@ -25,7 +25,7 @@
 #' }
 #'
 #' @export
-download_data_wrds <- function(type, start_date, end_date) {
+download_data_wrds <- function(type, start_date = NULL, end_date = NULL) {
 
   check_supported_type(type)
 

--- a/R/download_data_wrds_clean_trace.R
+++ b/R/download_data_wrds_clean_trace.R
@@ -32,8 +32,8 @@ download_data_wrds_clean_trace <- function(
   in_schema <- getNamespace("dbplyr")$in_schema
 
   if (is.null(start_date) || is.null(end_date)) {
-    start_date <- Sys.Date() - 720
-    end_date <- Sys.Date() - 365
+    start_date <- Sys.Date() %m-% years(2)
+    end_date <- Sys.Date() %m-% years(1)
     message("No start_date or end_date provided. Using the range ",
             start_date, " to ", end_date, " to avoid downloading large amounts of data.")
   } else {

--- a/R/download_data_wrds_clean_trace.R
+++ b/R/download_data_wrds_clean_trace.R
@@ -5,8 +5,10 @@
 #' The trade data is cleaned as suggested by Dick-Nielsen (2009, 2014).
 #'
 #' @param cusips A character vector specifying the 9-digit CUSIPs to download.
-#' @param start_date The start date for filtering the data, in "YYYY-MM-DD" format.
-#' @param end_date The end date for filtering the data, in "YYYY-MM-DD" format.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, a subset of the dataset is returned.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, a subset of the dataset is returned.
 #'
 #' @return A data frame containing the cleaned trade messages from TRACE for the
 #'   selected CUSIPs over the time window specified. Output variables include
@@ -22,11 +24,22 @@
 #' @importFrom lubridate as_datetime
 #'
 #' @export
-download_data_wrds_clean_trace <- function(cusips, start_date, end_date) {
+download_data_wrds_clean_trace <- function(
+    cusips, start_date = NULL, end_date = NULL
+  ){
 
   check_if_package_installed("dbplyr", "clean_trace")
-
   in_schema <- getNamespace("dbplyr")$in_schema
+
+  if (is.null(start_date) || is.null(end_date)) {
+    start_date <- Sys.Date() - 720
+    end_date <- Sys.Date() - 365
+    message("No start_date or end_date provided. Using the range ",
+            start_date, " to ", end_date, " to avoid downloading large amounts of data.")
+  } else {
+    start_date <- as.Date(start_date)
+    end_date <- as.Date(end_date)
+  }
 
   con <- get_wrds_connection()
 

--- a/R/download_data_wrds_compustat.R
+++ b/R/download_data_wrds_compustat.R
@@ -7,8 +7,10 @@
 #' (inv) for each company.
 #'
 #' @param type The type of financial data to download.
-#' @param start_date The start date for the data retrieval in "YYYY-MM-DD" format.
-#' @param end_date The end date for the data retrieval in "YYYY-MM-DD" format.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, a subset of the dataset is returned.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, a subset of the dataset is returned.
 #' @param additional_columns Additional columns from the Compustat table
 #'   as a character vector.
 #'
@@ -29,16 +31,24 @@
 #' @importFrom lubridate year
 #'
 #' @export
-download_data_wrds_compustat <- function(type, start_date, end_date, additional_columns = NULL) {
+download_data_wrds_compustat <- function(
+    type, start_date = NULL, end_date = NULL, additional_columns = NULL
+  ) {
 
   check_if_package_installed("dbplyr", type)
-
   in_schema <- getNamespace("dbplyr")$in_schema
 
-  con <- get_wrds_connection()
+  if (is.null(start_date) || is.null(end_date)) {
+    start_date <- Sys.Date() - 720
+    end_date <- Sys.Date() - 365
+    message("No start_date or end_date provided. Using the range ",
+            start_date, " to ", end_date, " to avoid downloading large amounts of data.")
+  } else {
+    start_date <- as.Date(start_date)
+    end_date <- as.Date(end_date)
+  }
 
-  start_date <- as.Date(start_date)
-  end_date <- as.Date(end_date)
+  con <- get_wrds_connection()
 
   if (grepl("compustat_annual", type, fixed = TRUE)) {
     funda_db <- tbl(con, in_schema("comp", "funda"))

--- a/R/download_data_wrds_compustat.R
+++ b/R/download_data_wrds_compustat.R
@@ -39,8 +39,8 @@ download_data_wrds_compustat <- function(
   in_schema <- getNamespace("dbplyr")$in_schema
 
   if (is.null(start_date) || is.null(end_date)) {
-    start_date <- Sys.Date() - 720
-    end_date <- Sys.Date() - 365
+    start_date <- Sys.Date() %m-% years(2)
+    end_date <- Sys.Date() %m-% years(1)
     message("No start_date or end_date provided. Using the range ",
             start_date, " to ", end_date, " to avoid downloading large amounts of data.")
   } else {

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -7,8 +7,10 @@
 #'
 #' @param type A string specifying the type of CRSP data to download:
 #'   "crsp_monthly" or "crsp_daily".
-#' @param start_date The start date for the data retrieval in "YYYY-MM-DD" format.
-#' @param end_date The end date for the data retrieval in "YYYY-MM-DD" format.
+#' @param start_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the start date for the data. If not provided, a subset of the dataset is returned.
+#' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
+#'   specifying the end date for the data. If not provided, a subset of the dataset is returned.
 #' @param batch_size An optional integer specifying the batch size for
 #'   processing daily data, with a default of 500.
 #' @param version An optional character specifying which CRSP version to use.
@@ -37,15 +39,31 @@
 #' @import lubridate
 #'
 #' @export
-download_data_wrds_crsp <- function(type, start_date, end_date, batch_size = 500, version = "v2", additional_columns = NULL) {
+download_data_wrds_crsp <- function(
+    type, start_date = NULL, end_date = NULL, batch_size = 500, version = "v2", additional_columns = NULL
+  ) {
 
-  if (!(version %in% c("v1", "v2"))) stop("Parameter version must be equal to v1 or v2.")
+  batch_size <- as.integer(batch_size)
+  if (batch_size <= 0) {
+    stop("Paramter 'batch_size' must be an integer larger than 0.")
+  }
+
+  if (!(version %in% c("v1", "v2"))) {
+    stop("Parameter 'versionÄ must be a character equal to 'v1' or 'v2'.")
+  }
 
   check_if_package_installed("dbplyr", type)
-  start_date <- as.Date(start_date)
-  end_date <- as.Date(end_date)
-
   in_schema <- getNamespace("dbplyr")$in_schema
+
+  if (is.null(start_date) || is.null(end_date)) {
+    start_date <- Sys.Date() - 720
+    end_date <- Sys.Date() - 365
+    message("No start_date or end_date provided. Using the range ",
+            start_date, " to ", end_date, " to avoid downloading large amounts of data.")
+  } else {
+    start_date <- as.Date(start_date)
+    end_date <- as.Date(end_date)
+  }
 
   con <- get_wrds_connection()
 

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -49,15 +49,15 @@ download_data_wrds_crsp <- function(
   }
 
   if (!(version %in% c("v1", "v2"))) {
-    stop("Parameter 'versionÄ must be a character equal to 'v1' or 'v2'.")
+    stop("Parameter 'version' must be a character equal to 'v1' or 'v2'.")
   }
 
   check_if_package_installed("dbplyr", type)
   in_schema <- getNamespace("dbplyr")$in_schema
 
   if (is.null(start_date) || is.null(end_date)) {
-    start_date <- Sys.Date() - 720
-    end_date <- Sys.Date() - 365
+    start_date <- Sys.Date() %m-% years(2)
+    end_date <- Sys.Date() %m-% years(1)
     message("No start_date or end_date provided. Using the range ",
             start_date, " to ", end_date, " to avoid downloading large amounts of data.")
   } else {

--- a/R/download_data_wrds_fisd.R
+++ b/R/download_data_wrds_fisd.R
@@ -26,7 +26,6 @@
 download_data_wrds_fisd <- function() {
 
   check_if_package_installed("dbplyr", "fisd_mergedissue")
-
   in_schema <- getNamespace("dbplyr")$in_schema
 
   con <- get_wrds_connection()

--- a/R/list_supported_types.R
+++ b/R/list_supported_types.R
@@ -407,6 +407,7 @@ list_supported_types_wrds <- function() {
     "wrds_crsp_monthly", "crsp.msf, crsp.msenames, crsp.msedelist",
     "wrds_crsp_daily", "crsp.dsf, crsp.msenames, crsp.msedelist",
     "wrds_compustat_annual", "comp.funda",
+    "wrds_compustat_quarterly", "comp.fundq",
     "wrds_ccm_links", "crsp.ccmxpf_linktable",
     "wrds_fisd", "fisd.fisd_mergedissue, fisd.fisd_mergedissuer",
     "wrds_trace", "trace.trace_enhanced"

--- a/man/download_data.Rd
+++ b/man/download_data.Rd
@@ -4,16 +4,19 @@
 \alias{download_data}
 \title{Download and Process Data Based on Type}
 \usage{
-download_data(type, start_date, end_date)
+download_data(type, start_date = NULL, end_date = NULL)
 }
 \arguments{
 \item{type}{The type of dataset to download, indicating either factor data or
 macroeconomic predictors.}
 
-\item{start_date}{The start date for filtering the data, in "YYYY-MM-DD"
-format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, the full dataset or a subset is returned,
+dependening on the dataset type.}
 
-\item{end_date}{The end date for filtering the data, in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, the full dataset or a subset is returned,
+depending on the dataset type.}
 }
 \value{
 A tibble with processed data, including dates and the relevant

--- a/man/download_data_factors.Rd
+++ b/man/download_data_factors.Rd
@@ -4,7 +4,7 @@
 \alias{download_data_factors}
 \title{Download and Process Factor Data}
 \usage{
-download_data_factors(type, start_date, end_date)
+download_data_factors(type, start_date = NULL, end_date = NULL)
 }
 \arguments{
 \item{type}{The type of dataset to download, indicating the factor model and

--- a/man/download_data_factors_ff.Rd
+++ b/man/download_data_factors_ff.Rd
@@ -4,16 +4,17 @@
 \alias{download_data_factors_ff}
 \title{Download and Process Fama-French Factor Data}
 \usage{
-download_data_factors_ff(type, start_date, end_date)
+download_data_factors_ff(type, start_date = NULL, end_date = NULL)
 }
 \arguments{
 \item{type}{The type of dataset to download, corresponding to the specific
 Fama-French model and frequency.}
 
-\item{start_date}{The start date for filtering the data, in "YYYY-MM-DD"
-format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, the full dataset is returned.}
 
-\item{end_date}{The end date for filtering the data, in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, the full dataset is returned.}
 }
 \value{
 A tibble with processed factor data, including the date, risk-free

--- a/man/download_data_factors_q.Rd
+++ b/man/download_data_factors_q.Rd
@@ -6,8 +6,8 @@
 \usage{
 download_data_factors_q(
   type,
-  start_date,
-  end_date,
+  start_date = NULL,
+  end_date = NULL,
   url = "http://global-q.org/uploads/1/2/2/6/122679606/"
 )
 }
@@ -15,10 +15,11 @@ download_data_factors_q(
 \item{type}{The type of dataset to download (e.g., "factors_q5_daily",
 "factors_q5_monthly").}
 
-\item{start_date}{The start date for filtering the data, in "YYYY-MM-DD"
-format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, the full dataset is returned.}
 
-\item{end_date}{The end date for filtering the data, in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, the full dataset is returned.}
 
 \item{url}{The base URL from which to download the dataset files, with a
 specific path for Global Q datasets.}

--- a/man/download_data_macro_predictors.Rd
+++ b/man/download_data_macro_predictors.Rd
@@ -6,8 +6,8 @@
 \usage{
 download_data_macro_predictors(
   type,
-  start_date,
-  end_date,
+  start_date = NULL,
+  end_date = NULL,
   url = "https://docs.google.com/spreadsheets/d/1g4LOaRj4TvwJr9RIaA_nwrXXWTOy46bP"
 )
 }
@@ -15,9 +15,11 @@ download_data_macro_predictors(
 \item{type}{The type of dataset to download ("macro_predictors_monthly",
 "macro_predictors_quarterly", "macro_predictors_annual").}
 
-\item{start_date}{The start date for filtering the data, in "YYYY-MM-DD" format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, the full dataset is returned.}
 
-\item{end_date}{The end date for filtering the data, in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, the full dataset is returned.}
 
 \item{url}{The URL from which to download the dataset, with a default Google
 Sheets export link.}

--- a/man/download_data_wrds.Rd
+++ b/man/download_data_wrds.Rd
@@ -4,7 +4,7 @@
 \alias{download_data_wrds}
 \title{Download Data from WRDS}
 \usage{
-download_data_wrds(type, start_date, end_date)
+download_data_wrds(type, start_date = NULL, end_date = NULL)
 }
 \arguments{
 \item{type}{A string specifying the type of data to download. It should match
@@ -12,11 +12,11 @@ one of the predefined patterns to indicate the dataset: "wrds_crsp" for
 CRSP data, "wrds_compustat" for Compustat data, or "wrds_ccm_links" for CCM
 links data.}
 
-\item{start_date}{A date in 'YYYY-MM-DD' format indicating the start of the
-period for which data is requested.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, a subset of the dataset is returned.}
 
-\item{end_date}{A date in 'YYYY-MM-DD' format indicating the end of the
-period for which data is requested.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, a subste of the dataset is returned.}
 }
 \value{
 A data frame containing the requested data, with the structure and

--- a/man/download_data_wrds_clean_trace.Rd
+++ b/man/download_data_wrds_clean_trace.Rd
@@ -4,14 +4,16 @@
 \alias{download_data_wrds_clean_trace}
 \title{Download Cleaned TRACE Data from WRDS}
 \usage{
-download_data_wrds_clean_trace(cusips, start_date, end_date)
+download_data_wrds_clean_trace(cusips, start_date = NULL, end_date = NULL)
 }
 \arguments{
 \item{cusips}{A character vector specifying the 9-digit CUSIPs to download.}
 
-\item{start_date}{The start date for filtering the data, in "YYYY-MM-DD" format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, a subset of the dataset is returned.}
 
-\item{end_date}{The end date for filtering the data, in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, a subset of the dataset is returned.}
 }
 \value{
 A data frame containing the cleaned trade messages from TRACE for the

--- a/man/download_data_wrds_compustat.Rd
+++ b/man/download_data_wrds_compustat.Rd
@@ -6,17 +6,19 @@
 \usage{
 download_data_wrds_compustat(
   type,
-  start_date,
-  end_date,
+  start_date = NULL,
+  end_date = NULL,
   additional_columns = NULL
 )
 }
 \arguments{
 \item{type}{The type of financial data to download.}
 
-\item{start_date}{The start date for the data retrieval in "YYYY-MM-DD" format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, a subset of the dataset is returned.}
 
-\item{end_date}{The end date for the data retrieval in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, a subset of the dataset is returned.}
 
 \item{additional_columns}{Additional columns from the Compustat table
 as a character vector.}

--- a/man/download_data_wrds_crsp.Rd
+++ b/man/download_data_wrds_crsp.Rd
@@ -6,8 +6,8 @@
 \usage{
 download_data_wrds_crsp(
   type,
-  start_date,
-  end_date,
+  start_date = NULL,
+  end_date = NULL,
   batch_size = 500,
   version = "v2",
   additional_columns = NULL
@@ -17,9 +17,11 @@ download_data_wrds_crsp(
 \item{type}{A string specifying the type of CRSP data to download:
 "crsp_monthly" or "crsp_daily".}
 
-\item{start_date}{The start date for the data retrieval in "YYYY-MM-DD" format.}
+\item{start_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the start date for the data. If not provided, a subset of the dataset is returned.}
 
-\item{end_date}{The end date for the data retrieval in "YYYY-MM-DD" format.}
+\item{end_date}{Optional. A character string or Date object in "YYYY-MM-DD" format
+specifying the end date for the data. If not provided, a subset of the dataset is returned.}
 
 \item{batch_size}{An optional integer specifying the batch size for
 processing daily data, with a default of 500.}


### PR DESCRIPTION
Still needs to be tested thoroughly. A bit ugly that the top level function passes NULL down to the children, which means that _wrds_compustat() and others have to replace this NULL by sensible defaults in the function body (not possible in definition). 