### PR TITLE
docs: same roxygen order in docs

### DIFF
--- a/R/assign_portfolio.R
+++ b/R/assign_portfolio.R
@@ -22,8 +22,13 @@
 #'   Exchanges must be stored in a column named `exchange` in `data`. If `NULL`,
 #'   no filtering is applied.
 #'
-#' @return A vector of portfolio assignments for each row in the input `data`.
+#' @returns A vector of portfolio assignments for each row in the input `data`.
 #'
+#' @note This function will stop and throw an error if both `n_portfolios` and
+#'   `percentiles` are provided or if neither is provided. Ensure that you only
+#'   use one of these parameters for specifying portfolio breakpoints.
+#'
+#' @export
 #' @examples
 #' data <- data.frame(
 #'   id = 1:100,
@@ -32,12 +37,6 @@
 #' )
 #' assign_portfolio(data, "market_cap", n_portfolios = 5)
 #' assign_portfolio(data, "market_cap", percentiles = c(0.2, 0.4, 0.6, 0.8), exchanges = c("NYSE"))
-#'
-#' @export
-#'
-#' @note This function will stop and throw an error if both `n_portfolios` and
-#'   `percentiles` are provided or if neither is provided. Ensure that you only
-#'   use one of these parameters for specifying portfolio breakpoints.
 assign_portfolio <- function(data,
                              sorting_variable,
                              n_portfolios = NULL,

--- a/R/check_if_package_installed.R
+++ b/R/check_if_package_installed.R
@@ -7,7 +7,7 @@
 #' @param package The name of the package to check.
 #' @param type The type for which the package needs to be available.
 #'
-#' @return Invisible `TRUE` if the package is installed; otherwise, it stops
+#' @returns Invisible `TRUE` if the package is installed; otherwise, it stops
 #'   execution with an error message advising the installation of the package.
 #'   Since the function is designed to stop if the package is not found, it does
 #'   not explicitly return a value upon successful completion.

--- a/R/check_supported_type.R
+++ b/R/check_supported_type.R
@@ -7,10 +7,9 @@
 #'
 #' @param type The dataset type to check for support.
 #'
-#' @return Does not return a value; instead, it either passes silently if the
+#' @returns Does not return a value; instead, it either passes silently if the
 #'   type is supported or stops execution with an error message if the type is
 #'   unsupported.
-#'
 check_supported_type <- function(type) {
   supported_types <- list_supported_types(as_vector = TRUE)
   if (!any(type %in% supported_types)) {

--- a/R/create_summary_statistics.R
+++ b/R/create_summary_statistics.R
@@ -6,19 +6,6 @@
 #' groups specified by the `by` argument. Additional detail levels for quantiles
 #' can be included.
 #'
-#' @param data A data frame containing the variables to be summarized.
-#' @param ... Comma-separated list of unquoted variable names in the data frame
-#'   to summarize. These variables must be either numeric, integer, or logical.
-#' @param by An optional unquoted variable name to group the data before
-#'   summarizing. If NULL (the default), summary statistics are computed across
-#'   all observations.
-#' @param detail A logical flag indicating whether to compute detailed summary
-#'   statistics including additional quantiles. Defaults to FALSE, which
-#'   computes basic statistics (n, mean, sd, min, median, max). When TRUE,
-#'   additional quantiles (1%, 5%, 10%, 25%, 75%, 90%, 95%, 99%) are computed.
-#' @param drop_na A logical flag indicating whether to drop missing values for
-#'   each variabl (default is FALSE).
-#'
 #' @details The function first checks that all specified variables are of type
 #' numeric, integer, or logical. If any variables do not meet this criterion,
 #' the function stops and returns an error message indicating the non-conforming
@@ -33,7 +20,20 @@
 #' `by` variable is provided, statistics are computed within each level of the
 #' `by` variable.
 #'
-#' @return A tibble with summary statistics for each selected variable. If `by`
+#' @param data A data frame containing the variables to be summarized.
+#' @param ... Comma-separated list of unquoted variable names in the data frame
+#'   to summarize. These variables must be either numeric, integer, or logical.
+#' @param by An optional unquoted variable name to group the data before
+#'   summarizing. If `NULL` (the default), summary statistics are computed across
+#'   all observations.
+#' @param detail A logical flag indicating whether to compute detailed summary
+#'   statistics including additional quantiles. Defaults to FALSE, which
+#'   computes basic statistics (n, mean, sd, min, median, max). When TRUE,
+#'   additional quantiles (1%, 5%, 10%, 25%, 75%, 90%, 95%, 99%) are computed.
+#' @param drop_na A logical flag indicating whether to drop missing values for
+#'   each variabl (default is FALSE).
+#'
+#' @returns A tibble with summary statistics for each selected variable. If `by`
 #'   is specified, the output includes the grouping variable as well. Each row
 #'   represents a variable (and a group if `by` is used), and columns include
 #'   the computed statistics.

--- a/R/create_wrds_dummy_database.R
+++ b/R/create_wrds_dummy_database.R
@@ -7,13 +7,12 @@
 #' @param path The file path where the SQLite database should be saved. If not
 #'   provided, the default path is "data/tidy_finance_r.sqlite".
 #'
-#' @return Invisible NULL. Side effect: downloads a file to the specified path.
+#' @returns Invisible `NULL`. Side effect: downloads a file to the specified path.
 #'
+#' @export
 #' @examples
 #' path <- paste0(tempdir(), "/tidy_finance_r.sqlite")
 #' create_wrds_dummy_database(path)
-#'
-#' @export
 create_wrds_dummy_database <- function(path) {
 
   if (missing(path)) {

--- a/R/disconnect_connection.R
+++ b/R/disconnect_connection.R
@@ -5,7 +5,8 @@
 #'
 #' @param con A database connection object created by DBI::dbConnect or any
 #'   similar function that establishes a connection to a database.
-#' @return A logical value: `TRUE` if disconnection was successful, `FALSE`
+#'
+#' @returns A logical value: `TRUE` if disconnection was successful, `FALSE`
 #'   otherwise.
 #'
 #' @export

--- a/R/download_data.R
+++ b/R/download_data.R
@@ -15,16 +15,15 @@
 #'   specifying the end date for the data. If not provided, the full dataset or a subset is returned,
 #'   depending on the dataset type.
 #'
-#' @return A tibble with processed data, including dates and the relevant
+#' @returns A tibble with processed data, including dates and the relevant
 #'   financial metrics, filtered by the specified date range.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   download_data("factors_ff_3_monthly", "2000-01-01", "2020-12-31")
 #'   download_data("macro_predictors_monthly", "2000-01-01", "2020-12-31")
 #' }
-#'
-#' @export
 download_data <- function(type, start_date, end_date) {
 
   check_supported_type(type)

--- a/R/download_data_factors.R
+++ b/R/download_data_factors.R
@@ -12,18 +12,17 @@
 #'   format.
 #' @param end_date The end date for filtering the data, in "YYYY-MM-DD" format.
 #'
-#' @return A tibble with processed factor data, including dates, risk-free
+#' @returns A tibble with processed factor data, including dates, risk-free
 #'   rates, market excess returns, and other factors, filtered by the specified
 #'   date range.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   download_data_factors("factors_ff_3_monthly", "2000-01-01", "2020-12-31")
 #'   download_data_factors("factors_ff_3_daily")
 #'   download_data_factors("factors_q5_daily", "2020-01-01", "2020-12-31")
 #' }
-#'
-#' @export
 download_data_factors <- function(
     type, start_date, end_date
   ) {
@@ -61,16 +60,16 @@ download_data_factors <- function(
 #' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
 #'   specifying the end date for the data. If not provided, the full dataset is returned.
 #'
-#' @return A tibble with processed factor data, including the date, risk-free
+#' @returns A tibble with processed factor data, including the date, risk-free
 #'   rate, market excess return, and other factors, filtered by the specified
 #'   date range.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   download_data_factors_ff("factors_ff_3_monthly", "2000-01-01", "2020-12-31")
 #'   download_data_factors_ff("factors_ff_10_industry_portfolios_monthly", "2000-01-01", "2020-12-31")
 #' }
-#' @export
 download_data_factors_ff <- function(
     type, start_date, end_date
   ) {
@@ -144,15 +143,15 @@ download_data_factors_ff <- function(
 #' @param url The base URL from which to download the dataset files, with a
 #'   specific path for Global Q datasets.
 #'
-#' @return A tibble with processed factor data, including the date, risk-free
+#' @returns A tibble with processed factor data, including the date, risk-free
 #'   rate, market excess return, and other factors, filtered by the specified
 #'   date range.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   download_data_factors_q("factors_q5_daily", "2020-01-01", "2020-12-31")
 #' }
-#' @export
 download_data_factors_q <- function(
     type, start_date, end_date, url = "http://global-q.org/uploads/1/2/2/6/122679606/"
 ) {

--- a/R/download_data_macro_predictors.R
+++ b/R/download_data_macro_predictors.R
@@ -16,14 +16,14 @@
 #' @param url The URL from which to download the dataset, with a default Google
 #'   Sheets export link.
 #'
-#' @return A tibble with processed data, filtered by the specified date range
+#' @returns A tibble with processed data, filtered by the specified date range
 #'   and including financial metrics.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   macro_predictors_monthly <- download_data_macro_predictors("macro_predictors_monthly")
 #' }
-#' @export
 download_data_macro_predictors <- function(
     type, start_date, end_date, url = "https://docs.google.com/spreadsheets/d/1g4LOaRj4TvwJr9RIaA_nwrXXWTOy46bP"
   ) {

--- a/R/download_data_stocks.R
+++ b/R/download_data_stocks.R
@@ -10,14 +10,13 @@
 #' @param symbols A character vector of stock symbols to download data for. At least one
 #'   symbol must be provided.
 #'
-#' @return A tibble containing the downloaded stock data with columns depending on the data source.
+#' @returns A tibble containing the downloaded stock data with columns depending on the data source.
 #'
+#' @export
 #' @examples
 #' \dontrun{
 #' download_data_stocks(type = "stocks_yf", symbols = c("AAPL", "MSFT"))
 #' }
-#'
-#' @export
 download_data_stocks <- function(type, start_date, end_date, symbols) {
 
   check_supported_type(type)
@@ -40,16 +39,16 @@ download_data_stocks <- function(type, start_date, end_date, symbols) {
 #' @param symbols A character vector of stock symbols to download data for. At least one
 #'   symbol must be provided.
 #'
-#' @return A tibble containing the downloaded stock data with columns: symbol,
+#' @returns A tibble containing the downloaded stock data with columns: symbol,
 #'   date, volume, open, low, high, close, and adjusted_close.
 #'
+#' @export
 #' @examples
 #' \dontrun{
 #' download_data_stocks_yf(symbols = c("AAPL", "MSFT"))
 #'
 #' download_data_stocks_yf("2021-01-01", "2022-01-01", symbols = "GOOGL")
 #' }
-#' @export
 download_data_stocks_yf <- function(start_date, end_date, symbols) {
 
   if (missing(symbols)) {

--- a/R/download_data_wrds.R
+++ b/R/download_data_wrds.R
@@ -14,17 +14,16 @@
 #' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
 #'   specifying the end date for the data. If not provided, a subste of the dataset is returned.
 #'
-#' @return A data frame containing the requested data, with the structure and
+#' @returns A data frame containing the requested data, with the structure and
 #'   contents depending on the specified `type`.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   crsp_monthly <- download_data_wrds("wrds_crsp_monthly", "2020-01-01", "2020-12-31")
 #'   compustat_annual <- download_data_wrds("wrds_compustat_annual", "2020-01-01", "2020-12-31")
 #'   ccm_links <- download_data_wrds("wrds_ccm_links", "2020-01-01", "2020-12-31")
 #' }
-#'
-#' @export
 download_data_wrds <- function(type, start_date, end_date) {
 
   check_supported_type(type)

--- a/R/download_data_wrds_ccm_links.R
+++ b/R/download_data_wrds_ccm_links.R
@@ -14,15 +14,15 @@
 #' @param usedflag An integer indicating whether to use flagged links. The
 #'   default is `1`, indicating that only flagged links should be used.
 #'
-#' @return A data frame with the columns `permno`, `gvkey`, `linkdt`, and
+#' @returns A data frame with the columns `permno`, `gvkey`, `linkdt`, and
 #'   `linkenddt`, where `linkenddt` is the end date of the link, and missing end
 #'   dates are replaced with today's date.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   ccm_links <- download_data_wrds_ccm_links(linktype = "LU", linkprim = "P", usedflag = 1)
 #' }
-#' @export
 download_data_wrds_ccm_links <- function(
     linktype = c("LU", "LC"), linkprim = c("P", "C"), usedflag = 1
 ) {

--- a/R/download_data_wrds_clean_trace.R
+++ b/R/download_data_wrds_clean_trace.R
@@ -10,17 +10,16 @@
 #' @param end_date Optional. A character string or Date object in "YYYY-MM-DD" format
 #'   specifying the end date for the data. If not provided, a subset of the dataset is returned.
 #'
-#' @return A data frame containing the cleaned trade messages from TRACE for the
+#' @returns A data frame containing the cleaned trade messages from TRACE for the
 #'   selected CUSIPs over the time window specified. Output variables include
 #'   identifying information (i.e., CUSIP, trade date/time) and trade-specific
 #'   information (i.e., price/yield, volume, counterparty, and reporting side).
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   clean_trace <- download_data_wrds_clean_trace("00101JAH9", "2019-01-01", "2021-12-31")
 #' }
-#'
-#' @export
 download_data_wrds_clean_trace <- function(
     cusips, start_date, end_date
   ) {

--- a/R/download_data_wrds_compustat.R
+++ b/R/download_data_wrds_compustat.R
@@ -15,10 +15,11 @@
 #' @param additional_columns Additional columns from the Compustat table
 #'   as a character vector.
 #'
-#' @return A data frame with financial data for the specified period, including
+#' @returns A data frame with financial data for the specified period, including
 #'   variables for book equity (be), operating profitability (op), investment
 #'   (inv), and others.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   download_data_wrds_compustat("wrds_compustat_annual", "2020-01-01", "2020-12-31")
@@ -27,8 +28,6 @@
 #'   # Add additional columns
 #'   download_data_wrds_compustat("wrds_compustat_annual", additional_columns = c("aodo", "aldo"))
 #' }
-#'
-#' @export
 download_data_wrds_compustat <- function(
     type, start_date, end_date, additional_columns = NULL
   ) {

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -19,11 +19,12 @@
 #' @param additional_columns Additional columns from the CRSP monthly or
 #'   daily data as a character vector.
 #'
-#' @return A data frame containing CRSP stock returns, adjusted for delistings,
+#' @returns A data frame containing CRSP stock returns, adjusted for delistings,
 #'   along with calculated market capitalization and excess returns over the
 #'   risk-free rate. The structure of the returned data frame depends on the
 #'   selected data type.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   crsp_monthly <- download_data_wrds_crsp("wrds_crsp_monthly", "2020-11-01", "2020-12-31")
@@ -33,7 +34,6 @@
 #'   download_data_wrds_crsp("wrds_crsp_monthly", "2020-11-01", "2020-12-31",
 #'                           additional_columns = c("mthvol", "mthvolflg"))
 #' }
-#' @export
 download_data_wrds_crsp <- function(
     type, start_date, end_date, batch_size = 500, version = "v2", additional_columns = NULL
   ) {

--- a/R/download_data_wrds_fisd.R
+++ b/R/download_data_wrds_fisd.R
@@ -12,19 +12,18 @@
 #' @param additional_columns Additional columns from the FISD table
 #'   as a character vector.
 #'
-#' @return A data frame containing a subset of FISD data with fields related to
+#' @returns A data frame containing a subset of FISD data with fields related to
 #'   the bond's characteristics and issuer information. This includes complete
 #'   CUSIP, maturity date, offering amount, offering date, dated date, interest
 #'   frequency, coupon, last interest date, issue ID, issuer ID, SIC code of the
 #'   issuer.
 #'
+#' @export
 #' @examples
 #' \donttest{
 #'   fisd <- download_data_wrds_fisd()
 #'   fisd_extended <- download_data_wrds_fisd(additional_columns = c("asset_backed", "defeased"))
 #' }
-#'
-#' @export
 download_data_wrds_fisd <- function(additional_columns = NULL) {
 
   check_if_package_installed("dbplyr", "fisd_mergedissue")

--- a/R/estimate_model.R
+++ b/R/estimate_model.R
@@ -16,11 +16,13 @@
 #' @param min_obs The minimum number of observations required to estimate the
 #'   model. Defaults to 1.
 #'
-#' @return If a single independent variable is specified, a numeric value
+#' @returns If a single independent variable is specified, a numeric value
 #'   representing the coefficient of that variable. If multiple independent
 #'   variables are specified, a data frame with a row for each coefficient and
 #'   column names corresponding to the independent variables.
 #'
+#' @seealso \code{\link[stats]{lm}} for details on the underlying linear model fitting used.
+#' @export
 #' @examples
 #' data <- data.frame(
 #'   ret_excess = rnorm(100),
@@ -33,9 +35,6 @@
 #'
 #' # Estimate model with multiple independent variables
 #' multi_var_model <- estimate_model(data, "ret_excess ~ mkt_excess + smb + hml")
-#'
-#' @export
-#' @seealso \code{\link[stats]{lm}} for details on the underlying linear model fitting used.
 estimate_model <- function(data, model, min_obs = 1) {
   model_parts <- strsplit(model, "~", fixed = TRUE)[[1]]
   response_var <- trimws(model_parts[1])

--- a/R/get_wrds_connection.R
+++ b/R/get_wrds_connection.R
@@ -5,16 +5,19 @@
 #' `RPostgres` package is installed and that valid WRDS credentials are set as
 #' environment variables.
 #'
-#' @return An object of class `DBIConnection` representing the connection to the
-#'   WRDS database. This object can be used with other DBI-compliant functions
-#'   to interact with the database.
-#'
 #' @details The function checks if the `RPostgres` package is installed before
 #'   attempting to establish a connection. It uses the host, dbname, port, and
 #'   sslmode as fixed parameters for the connection. Users must set their WRDS
 #'   username and password as environment variables `WRDS_USER` and
 #'   `WRDS_PASSWORD`, respectively, before using this function.
 #'
+#' @returns An object of class `DBIConnection` representing the connection to the
+#'   WRDS database. This object can be used with other DBI-compliant functions
+#'   to interact with the database.
+#'
+#' @seealso \code{\link[RPostgres]{Postgres}}, \code{\link[DBI]{dbDisconnect}} for more
+#'          information on managing database connections.
+#' @export
 #' @examples
 #' \donttest{
 #'   # Before using this function, set your WRDS credentials:
@@ -25,11 +28,6 @@
 #'   # Remember to disconnect after use:
 #'   # disconnect_connection(con)
 #' }
-#'
-#' @export
-#'
-#' @seealso \code{\link[RPostgres]{Postgres}}, \code{\link[DBI]{dbDisconnect}} for more
-#'          information on managing database connections.
 get_wrds_connection <- function() {
 
   if (!nzchar(Sys.getenv("WRDS_USER")) || !nzchar(Sys.getenv("WRDS_PASSWORD"))) {

--- a/R/list_supported_types.R
+++ b/R/list_supported_types.R
@@ -7,10 +7,9 @@
 #' factors). Additionally, it annotates each dataset with the domain
 #' "Fama-French".
 #'
-#' @return A tibble with columns: `type` (the type of dataset), `dataset_name`
+#' @returns A tibble with columns: `type` (the type of dataset), `dataset_name`
 #'   (a descriptive name of the dataset), and `domain` (the domain to which the
 #'   dataset belongs, always "Fama-French").
-#'
 list_supported_types_ff <- function() {
 
   # data_sets_raw <- frenchdata::get_french_data_list()$files_list
@@ -345,7 +344,7 @@ list_supported_types_ff <- function() {
 #' Q model, specifically the q5 factors model for the year 2022. Additionally,
 #' it annotates each dataset with the domain "Global Q".
 #'
-#' @return A tibble with columns: `type` (the type of dataset), `dataset_name`
+#' @returns A tibble with columns: `type` (the type of dataset), `dataset_name`
 #'   (the file name of the dataset), and `domain` (the domain to which the
 #'   dataset belongs, always "Global Q").
 list_supported_types_q <- function() {
@@ -369,7 +368,7 @@ list_supported_types_q <- function() {
 #' "PredictorData2022.xlsx" for the year 2022. Additionally, it annotates each
 #' dataset with the domain "Goyal-Welch".
 #'
-#' @return A tibble with columns: `type` (the type of dataset), `dataset_name`
+#' @returns A tibble with columns: `type` (the type of dataset), `dataset_name`
 #'   (the file name of the dataset, which is the same for all types), and
 #'   `domain` (the domain to which the dataset belongs, always "Goyal-Welch").
 list_supported_types_macro_predictors <- function() {
@@ -387,7 +386,7 @@ list_supported_types_macro_predictors <- function() {
 #' This function returns a tibble with the supported dataset types provided via
 #' WRDS. Additionally, it annotates each dataset with the domain "WRDS".
 #'
-#' @return A tibble with columns: `type` (the type of dataset), `dataset_name`
+#' @returns A tibble with columns: `type` (the type of dataset), `dataset_name`
 #'   (the file name of the dataset), and `domain` (the domain to which the
 #'   dataset belongs, always "WRDS").
 list_supported_types_wrds <- function() {
@@ -408,7 +407,7 @@ list_supported_types_wrds <- function() {
 #'
 #' Returns a tibble listing the supported stock data types and their corresponding dataset names.
 #'
-#' @return A tibble with columns \code{type} and \code{dataset_name}, where \code{type} indicates the code used to specify the data source and \code{dataset_name} provides the name of the data source.
+#' @returns A tibble with columns \code{type} and \code{dataset_name}, where \code{type} indicates the code used to specify the data source and \code{dataset_name} provides the name of the data source.
 list_supported_types_stocks <- function() {
   tibble(
     "type" = "stocks_yf",
@@ -428,11 +427,12 @@ list_supported_types_stocks <- function() {
 #' @param as_vector Logical indicating whether types should be returned as a
 #'   character vector instead of data frame.
 #'
-#' @return A tibble aggregating all supported dataset types with columns: `type`
+#' @returns A tibble aggregating all supported dataset types with columns: `type`
 #'   (the type of dataset), `dataset_name` (a descriptive name or file name of
 #'   the dataset), and `domain` (the domain to which the dataset belongs, e.g.,
 #'   "Global Q", "Fama-French", "Goyal-Welch").
 #'
+#' @export
 #' @examples
 #' # List all supported types as a data frame
 #' list_supported_types()
@@ -442,8 +442,6 @@ list_supported_types_stocks <- function() {
 #'
 #' # List supported types as a vector
 #' list_supported_types(as_vector = TRUE)
-#'
-#' @export
 list_supported_types <- function(domain = NULL, as_vector = FALSE) {
   supported_types <- dplyr::bind_rows(
     list_supported_types_q(),

--- a/R/list_tidy_finance_chapters.R
+++ b/R/list_tidy_finance_chapters.R
@@ -4,14 +4,13 @@
 #' the Tidy Finance resource. This function provides a quick reference to the
 #' various topics covered.
 #'
-#' @examples
-#' list_tidy_finance_chapters()
-#'
-#' @export
-#'
-#' @return A character vector where each element is the name of a chapter
+#' @returns A character vector where each element is the name of a chapter
 #'   available in the Tidy Finance resource. These names correspond to specific
 #'   chapters in Tidy Finance with R.
+#'
+#' @export
+#' @examples
+#' list_tidy_finance_chapters()
 list_tidy_finance_chapters <- function() {
   c(
     "setting-up-your-environment",

--- a/R/open_tidy_finance_website.R
+++ b/R/open_tidy_finance_website.R
@@ -11,14 +11,13 @@
 #'   "beta-estimation.html"). If the chapter name does not exist, then the
 #'   function opens the main page.
 #'
+#' @returns Invisible NULL. The function is called for its side effect of opening
+#'   a web page.
+#'
+#' @export
 #' @examples
 #' open_tidy_finance_website()
 #' open_tidy_finance_website("beta-estimation")
-#'
-#' @export
-#'
-#' @return Invisible NULL. The function is called for its side effect of opening
-#'   a web page.
 open_tidy_finance_website <- function(chapter = NULL) {
   base_url <- "https://www.tidy-finance.org/r/"
   if (!is.null(chapter)) {

--- a/R/open_tidy_finance_website.R
+++ b/R/open_tidy_finance_website.R
@@ -5,13 +5,13 @@
 #' constructs the URL to access the chapter directly.
 #'
 #' @param chapter An optional character string specifying the chapter to open.
-#'   If NULL (the default), the function opens the main page of Tidy Finance with R.
+#'   If `NULL` (the default), the function opens the main page of Tidy Finance with R.
 #'   If a chapter name is provided (e.g., "beta-estimation"), the
 #'   function opens the corresponding chapter's page (e.g.,
 #'   "beta-estimation.html"). If the chapter name does not exist, then the
 #'   function opens the main page.
 #'
-#' @returns Invisible NULL. The function is called for its side effect of opening
+#' @returns Invisible `NULL`. The function is called for its side effect of opening
 #'   a web page.
 #'
 #' @export

--- a/R/set_wrds_credentials.R
+++ b/R/set_wrds_credentials.R
@@ -8,12 +8,13 @@
 #' to add the .Renviron file to the .gitignore file to prevent it from being tracked
 #' by version control.
 #'
-#' @return Invisibly returns TRUE. Displays messages to the user based on their input and actions taken.
+#' @returns Invisibly returns TRUE. Displays messages to the user based on their input and actions taken.
+#'
+#' @export
 #' @examples
 #' \dontrun{
 #' set_wrds_credentials()
 #' }
-#' @export
 set_wrds_credentials <- function() {
   wrds_user <- readline(prompt = "Enter your WRDS username: ")
   wrds_password <- readline(prompt = "Enter your WRDS password: ")

--- a/R/trim.R
+++ b/R/trim.R
@@ -10,14 +10,13 @@
 #'   distribution. For example, a `cut` of 0.05 will remove the lowest and
 #'   highest 5% of the data. Must be between \[0, 0.5\].
 #'
-#' @return A numeric vector with the extreme values removed.
+#' @returns A numeric vector with the extreme values removed.
 #'
+#' @export
 #' @examples
 #' set.seed(123)
 #' data <- rnorm(100)
 #' trimmed_data <- trim(x = data, cut = 0.05)
-#'
-#' @export
 trim <- function(x, cut) {
   if (cut < 0 || cut > 0.5) {
     stop("The parameter 'cut' must be inside [0, 0.5].")

--- a/R/winsorize.R
+++ b/R/winsorize.R
@@ -9,15 +9,14 @@
 #'   distribution. For example, a `cut` of 0.05 will winsorize the lowest and
 #'   highest 5% of the data. Must be inside \[0, 0.5\].
 #'
-#' @return A numeric vector with the extreme values replaced by the
+#' @returns A numeric vector with the extreme values replaced by the
 #'   corresponding quantile values.
 #'
+#' @export
 #' @examples
 #' set.seed(123)
 #' data <- rnorm(100)
 #' winsorized_data <- winsorize(data, 0.05)
-#'
-#' @export
 winsorize <- function(x, cut) {
   if (cut < 0 || cut > 0.5) {
     stop("The parameter 'cut' must be inside [0, 0.5].")

--- a/man/assign_portfolio.Rd
+++ b/man/assign_portfolio.Rd
@@ -55,5 +55,4 @@ data <- data.frame(
 )
 assign_portfolio(data, "market_cap", n_portfolios = 5)
 assign_portfolio(data, "market_cap", percentiles = c(0.2, 0.4, 0.6, 0.8), exchanges = c("NYSE"))
-
 }

--- a/man/create_summary_statistics.Rd
+++ b/man/create_summary_statistics.Rd
@@ -19,7 +19,7 @@ create_summary_statistics(
 to summarize. These variables must be either numeric, integer, or logical.}
 
 \item{by}{An optional unquoted variable name to group the data before
-summarizing. If NULL (the default), summary statistics are computed across
+summarizing. If \code{NULL} (the default), summary statistics are computed across
 all observations.}
 
 \item{detail}{A logical flag indicating whether to compute detailed summary

--- a/man/create_wrds_dummy_database.Rd
+++ b/man/create_wrds_dummy_database.Rd
@@ -11,7 +11,7 @@ create_wrds_dummy_database(path)
 provided, the default path is "data/tidy_finance_r.sqlite".}
 }
 \value{
-Invisible NULL. Side effect: downloads a file to the specified path.
+Invisible \code{NULL}. Side effect: downloads a file to the specified path.
 }
 \description{
 Downloads the WRDS dummy database from the respective Tidy Finance GitHub
@@ -21,5 +21,4 @@ the user is prompted before it is replaced.
 \examples{
 path <- paste0(tempdir(), "/tidy_finance_r.sqlite")
 create_wrds_dummy_database(path)
-
 }

--- a/man/download_data.Rd
+++ b/man/download_data.Rd
@@ -33,5 +33,4 @@ appropriate function for downloading and processing the data.
   download_data("factors_ff_3_monthly", "2000-01-01", "2020-12-31")
   download_data("macro_predictors_monthly", "2000-01-01", "2020-12-31")
 }
-
 }

--- a/man/download_data_factors.Rd
+++ b/man/download_data_factors.Rd
@@ -33,5 +33,4 @@ processing.
   download_data_factors("factors_ff_3_daily")
   download_data_factors("factors_q5_daily", "2020-01-01", "2020-12-31")
 }
-
 }

--- a/man/download_data_stocks.Rd
+++ b/man/download_data_stocks.Rd
@@ -28,5 +28,4 @@ Downloads historical stock data for a given symbol and date range from specified
 \dontrun{
 download_data_stocks(type = "stocks_yf", symbols = c("AAPL", "MSFT"))
 }
-
 }

--- a/man/download_data_wrds.Rd
+++ b/man/download_data_wrds.Rd
@@ -34,5 +34,4 @@ specific data download function.
   compustat_annual <- download_data_wrds("wrds_compustat_annual", "2020-01-01", "2020-12-31")
   ccm_links <- download_data_wrds("wrds_ccm_links", "2020-01-01", "2020-12-31")
 }
-
 }

--- a/man/download_data_wrds_clean_trace.Rd
+++ b/man/download_data_wrds_clean_trace.Rd
@@ -30,5 +30,4 @@ The trade data is cleaned as suggested by Dick-Nielsen (2009, 2014).
 \donttest{
   clean_trace <- download_data_wrds_clean_trace("00101JAH9", "2019-01-01", "2021-12-31")
 }
-
 }

--- a/man/download_data_wrds_compustat.Rd
+++ b/man/download_data_wrds_compustat.Rd
@@ -44,5 +44,4 @@ operating profitability (op), and investment (inv) for each company.
   # Add additional columns
   download_data_wrds_compustat("wrds_compustat_annual", additional_columns = c("aodo", "aldo"))
 }
-
 }

--- a/man/download_data_wrds_fisd.Rd
+++ b/man/download_data_wrds_fisd.Rd
@@ -32,5 +32,4 @@ securities. It finally returns a data frame with selected fields from the
   fisd <- download_data_wrds_fisd()
   fisd_extended <- download_data_wrds_fisd(additional_columns = c("asset_backed", "defeased"))
 }
-
 }

--- a/man/estimate_model.Rd
+++ b/man/estimate_model.Rd
@@ -44,7 +44,6 @@ single_var_model <- estimate_model(data, "ret_excess ~ mkt_excess")
 
 # Estimate model with multiple independent variables
 multi_var_model <- estimate_model(data, "ret_excess ~ mkt_excess + smb + hml")
-
 }
 \seealso{
 \code{\link[stats]{lm}} for details on the underlying linear model fitting used.

--- a/man/get_wrds_connection.Rd
+++ b/man/get_wrds_connection.Rd
@@ -34,7 +34,6 @@ username and password as environment variables \code{WRDS_USER} and
   # Remember to disconnect after use:
   # disconnect_connection(con)
 }
-
 }
 \seealso{
 \code{\link[RPostgres]{Postgres}}, \code{\link[DBI]{dbDisconnect}} for more

--- a/man/list_supported_types.Rd
+++ b/man/list_supported_types.Rd
@@ -34,5 +34,4 @@ list_supported_types(domain = "WRDS")
 
 # List supported types as a vector
 list_supported_types(as_vector = TRUE)
-
 }

--- a/man/list_tidy_finance_chapters.Rd
+++ b/man/list_tidy_finance_chapters.Rd
@@ -18,5 +18,4 @@ various topics covered.
 }
 \examples{
 list_tidy_finance_chapters()
-
 }

--- a/man/open_tidy_finance_website.Rd
+++ b/man/open_tidy_finance_website.Rd
@@ -8,14 +8,14 @@ open_tidy_finance_website(chapter = NULL)
 }
 \arguments{
 \item{chapter}{An optional character string specifying the chapter to open.
-If NULL (the default), the function opens the main page of Tidy Finance with R.
+If \code{NULL} (the default), the function opens the main page of Tidy Finance with R.
 If a chapter name is provided (e.g., "beta-estimation"), the
 function opens the corresponding chapter's page (e.g.,
 "beta-estimation.html"). If the chapter name does not exist, then the
 function opens the main page.}
 }
 \value{
-Invisible NULL. The function is called for its side effect of opening
+Invisible \code{NULL}. The function is called for its side effect of opening
 a web page.
 }
 \description{
@@ -26,5 +26,4 @@ constructs the URL to access the chapter directly.
 \examples{
 open_tidy_finance_website()
 open_tidy_finance_website("beta-estimation")
-
 }

--- a/man/trim.Rd
+++ b/man/trim.Rd
@@ -26,5 +26,4 @@ values from both tails of the distribution.
 set.seed(123)
 data <- rnorm(100)
 trimmed_data <- trim(x = data, cut = 0.05)
-
 }

--- a/man/winsorize.Rd
+++ b/man/winsorize.Rd
@@ -26,5 +26,4 @@ tails of the distribution based on the \code{cut} parameter.
 set.seed(123)
 data <- rnorm(100)
 winsorized_data <- winsorize(data, 0.05)
-
 }


### PR DESCRIPTION
For sake of consistency have the same roxygen tags order (a la tidyverse) and replace `@return` with `@returns` since superseded: https://roxygen2.r-lib.org/reference/tags-rd.html

1. titel
2. description
3. details
4. params
5. returns
6. seealso
7. export
8. examples (last) -> benefit of not having the extra newline in the docs