### PR TITLE
Added `vcov_options` parameter to `estimate_fama_macbeth()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.4.0.9002
+Version: 0.4.0.9003
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph.scheuch@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 ## Improvements
 
 * Renamed `download_data_wrds_clean_trace()` to `download_data_wrds_trace_enhanced()` for improved consistency.
+* Added `vcov_options` parameter to `estimate_fama_macbeth()`
 
 # tidyfinance 0.4.0
 

--- a/man/estimate_fama_macbeth.Rd
+++ b/man/estimate_fama_macbeth.Rd
@@ -4,7 +4,13 @@
 \alias{estimate_fama_macbeth}
 \title{Estimate Fama-MacBeth Regressions}
 \usage{
-estimate_fama_macbeth(data, model, vcov = "newey-west", data_options = NULL)
+estimate_fama_macbeth(
+  data,
+  model,
+  vcov = "newey-west",
+  vcov_options = NULL,
+  data_options = NULL
+)
 }
 \arguments{
 \item{data}{A data frame containing the data for the regression. It must include a column
@@ -15,6 +21,12 @@ representing the time periods (defaults to \code{date}) and the variables specif
 \item{vcov}{A character string indicating the type of standard errors to compute. Options are
 \code{"iid"} for independent and identically distributed errors or \code{"newey-west"} for Newey-West
 standard errors. Default is \code{"newey-west"}.}
+
+\item{vcov_options}{A list of additional arguments to be passed to the
+\code{NeweyWest()} function when \code{vcov = "newey-west"}. These can include options
+such as \code{lag}, which specifies the number of lags to use in the Newey-West
+covariance matrix estimation, and \code{prewhite}, which indicates whether to
+apply a prewhitening transformation. Default is an empty list.}
 
 \item{data_options}{A named list of \link{data_options} with characters, indicating the column
 names required to run this function. The required column names identify dates. Defaults to
@@ -44,6 +56,8 @@ data <- tibble::tibble(
 
 estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap")
 estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap", vcov = "iid")
+estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap",
+                      vcov = "newey-west", vcov_options = list(lag = 6, prewhite = FALSE))
 
 # Use different column name for date
 data |>


### PR DESCRIPTION
I did not introduce a vcov_options() object (as for data_options) because we don't have to set any defaults. The default is actually NULL. 