### PR TITLE
Optimize winsorize function by reducing quantile recalculations

### DIFF
--- a/R/winsorize.R
+++ b/R/winsorize.R
@@ -24,9 +24,10 @@ winsorize <- function(x, cut) {
     cli::cli_abort("{.arg cut} must be inside [0, 0.5].")
   }
 
-  lb <- quantile(x, cut, na.rm = TRUE)
-  up <- quantile(x, 1 - cut, na.rm = TRUE)
-  x <- replace(x, x > up, up)
+  quantiles <- quantile(x, probs = c(cut, 1 - cut), na.rm = TRUE)
+  lb <- quantiles[1]
+  ub <- quantiles[2]
+  x <- replace(x, x > ub, ub)
   x <- replace(x, x < lb, lb)
   x
 }


### PR DESCRIPTION
This PR optimizes the winsorize() function by calculating the quantiles only once, reducing redundant computations. It assigns the lower and upper bounds to lb and ub for clarity.