### PR TITLE
unquote the date_col variable so it uses the actual column name stored in that variable, rather than creating a literal column named "date_col".

### DIFF
--- a/R/add_lag_columns.R
+++ b/R/add_lag_columns.R
@@ -106,5 +106,5 @@ add_lag_columns <- function(
   }
 
   result |>
-    rename(date_col := date)
+    rename(!!date_col := date)
 }


### PR DESCRIPTION
Fixes issue https://github.com/tidy-finance/r-tidyfinance/issues/151