### PR TITLE
fix: change breakpoints_secondary and breakpoints_min_size defaults from NA_real_ to NULL

### DIFF
--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -87,9 +87,11 @@ get_available_huggingface_files <- function(organization, dataset) {
 #'   `value` may be a vector to match multiple levels. Optionally pass
 #'   `fill_all = TRUE` to leave unspecified columns unrestricted (default:
 #'   `FALSE`, i.e. unspecified columns are fixed at the defaults listed below).
-#'   Passing an unrecognised column name raises an error listing the supported
-#'   names. Ignored when `dataset != "factor_library"`. See the Details section
-#'   for supported columns and their defaults.
+#'   Passing `NULL` for any parameter removes that filter entirely, returning
+#'   all values for that column (e.g., `exclude_size = NULL` includes all size
+#'   groups). Passing an unrecognised column name raises an error listing the
+#'   supported names. Ignored when `dataset != "factor_library"`. See the
+#'   Details section for supported columns and their defaults.
 #'
 #' @details
 #' **Note on `dataset = "factor_library"` defaults:** The defaults below reflect
@@ -121,16 +123,18 @@ get_available_huggingface_files <- function(organization, dataset) {
 #'     \item `sorting_method` (defaults to `"univariate"`): Whether portfolios
 #'       are formed on a single sort (`"univariate"`) or a sequential double
 #'       sort (`"sequential"`).
-#'     \item `breakpoints_secondary` (defaults to `NA` for univariate sorts):
-#'       Number of groups for the secondary sort variable. Required when
-#'       `sorting_method` is not `"univariate"`.
+#'     \item `breakpoints_secondary` (defaults to `NULL`; treated as `NA` for
+#'       univariate sorts): Number of groups for the secondary sort variable.
+#'       Required when `sorting_method` is not `"univariate"`. Note: explicitly
+#'       passing `NA` with a non-univariate `sorting_method` is not equivalent
+#'       to the default — it bypasses the validation and filters to portfolios
+#'       where `breakpoints_secondary` is `NA`, likely returning no results.
 #'     \item `breakpoints_exchanges` (defaults to: `"NYSE"`): Exchange(s) used
 #'       to compute breakpoints. `"NYSE"` uses only NYSE-listed stocks to
 #'       define quantile cutoffs (the conventional Fama-French approach).
 #'     \item `breakpoints_min_size` (defaults to `NA`): Minimum market-cap
 #'       threshold (in USD) applied when computing breakpoints. `NA` means no
-#'       minimum-size screen is applied. Pass `NULL` to remove this filter
-#'       entirely and include all portfolios regardless of size screen.
+#'       minimum-size screen is applied.
 #'     \item `weighting_scheme` (defaults to `"VW"`): Return weighting within
 #'       portfolios: `"VW"` for value-weighted or `"EW"` for equal-weighted.
 #'   }

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -318,6 +318,8 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
       sorting_variable = stringr::str_replace(.data$sorting_variable, "sv_", "")
     )
 
+  filters <- Filter(Negate(is.null), filters)
+
   for (col in names(filters)) {
     result <- dplyr::filter(result, .data[[col]] %in% filters[[col]])
   }

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -303,7 +303,7 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
   if (!fill_all) {
     for (col in names(defaults)) {
       if (!col %in% names(filters)) {
-        filters[[col]] <- defaults[[col]]
+        filters[col] <- list(defaults[[col]])
       }
     }
   }
@@ -318,7 +318,7 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
       sorting_variable = stringr::str_replace(.data$sorting_variable, "sv_", "")
     )
 
-  filters <- Filter(Negate(is.null), filters)
+  filters <- lapply(filters, function(x) if (is.null(x)) NA_real_ else x)
 
   for (col in names(filters)) {
     result <- dplyr::filter(result, .data[[col]] %in% filters[[col]])

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -264,7 +264,8 @@ check_supported_dataset_huggingface <- function(dataset) {
 #'     \item{`rebalancing`}{`"monthly"`}
 #'     \item{`breakpoints_main`}{`10`}
 #'     \item{`sorting_method`}{`"univariate"`}
-#'     \item{`breakpoints_secondary`}{`NA` for univariate sorts; required otherwise}
+#'     \item{`breakpoints_secondary`}{`NA` for univariate sorts;
+#'       required otherwise}
 #'     \item{`breakpoints_exchanges`}{`"NYSE"`}
 #'     \item{`breakpoints_min_size`}{`NA`}
 #'     \item{`weighting_scheme`}{`"VW"`}
@@ -317,7 +318,10 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
       if (!all(sorting_methods == "univariate")) {
         cli::cli_abort(c(
           "{.arg breakpoints_secondary} must be specified for bivariate sorts.",
-          "i" = "Provide a value for {.arg breakpoints_secondary} or use {.code fill_all = TRUE} to skip all defaults."
+          "i" = paste(
+            "Provide a value for {.arg breakpoints_secondary} or",
+            "use {.code fill_all = TRUE} to skip all defaults."
+          )
         ))
       }
       filters["breakpoints_secondary"] <- list(NA_real_)

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -121,14 +121,14 @@ get_available_huggingface_files <- function(organization, dataset) {
 #'     \item `sorting_method` (defaults to `"univariate"`): Whether portfolios
 #'       are formed on a single sort (`"univariate"`) or a sequential double
 #'       sort (`"sequential"`).
-#'     \item `breakpoints_secondary` (defaults to `NA`): Number of groups for
+#'     \item `breakpoints_secondary` (defaults to `NULL`): Number of groups for
 #'       the secondary sort variable; only relevant when
 #'       `sorting_method = "sequential"`.
 #'     \item `breakpoints_exchanges` (defaults to: `"NYSE"`): Exchange(s) used
 #'       to compute breakpoints. `"NYSE"` uses only NYSE-listed stocks to
 #'       define quantile cutoffs (the conventional Fama-French approach).
-#'     \item `breakpoints_min_size` (defaults to `NA`): Minimum market-cap
-#'       threshold (in USD) applied when computing breakpoints. `NA` means no
+#'     \item `breakpoints_min_size` (defaults to `NULL`): Minimum market-cap
+#'       threshold (in USD) applied when computing breakpoints. `NULL` means no
 #'       minimum-size screen is applied.
 #'     \item `weighting_scheme` (defaults to `"VW"`): Return weighting within
 #'       portfolios: `"VW"` for value-weighted or `"EW"` for equal-weighted.
@@ -259,9 +259,9 @@ check_supported_dataset_huggingface <- function(dataset) {
 #'     \item{`rebalancing`}{`"monthly"`}
 #'     \item{`breakpoints_main`}{`10`}
 #'     \item{`sorting_method`}{`"univariate"`}
-#'     \item{`breakpoints_secondary`}{`NA`}
+#'     \item{`breakpoints_secondary`}{`NULL`}
 #'     \item{`breakpoints_exchanges`}{`"NYSE"`}
-#'     \item{`breakpoints_min_size`}{`NA`}
+#'     \item{`breakpoints_min_size`}{`NULL`}
 #'     \item{`weighting_scheme`}{`"VW"`}
 #'   }
 #'   Each value can be a vector to match multiple levels.
@@ -285,9 +285,9 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
     rebalancing = "monthly",
     breakpoints_main = 10,
     sorting_method = "univariate",
-    breakpoints_secondary = NA_real_,
+    breakpoints_secondary = NULL,
     breakpoints_exchanges = "NYSE",
-    breakpoints_min_size = NA_real_,
+    breakpoints_min_size = NULL,
     weighting_scheme = "VW"
   )
 

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -121,15 +121,16 @@ get_available_huggingface_files <- function(organization, dataset) {
 #'     \item `sorting_method` (defaults to `"univariate"`): Whether portfolios
 #'       are formed on a single sort (`"univariate"`) or a sequential double
 #'       sort (`"sequential"`).
-#'     \item `breakpoints_secondary` (defaults to `NULL`): Number of groups for
-#'       the secondary sort variable; only relevant when
-#'       `sorting_method = "sequential"`.
+#'     \item `breakpoints_secondary` (defaults to `NA` for univariate sorts):
+#'       Number of groups for the secondary sort variable. Required when
+#'       `sorting_method` is not `"univariate"`.
 #'     \item `breakpoints_exchanges` (defaults to: `"NYSE"`): Exchange(s) used
 #'       to compute breakpoints. `"NYSE"` uses only NYSE-listed stocks to
 #'       define quantile cutoffs (the conventional Fama-French approach).
-#'     \item `breakpoints_min_size` (defaults to `NULL`): Minimum market-cap
-#'       threshold (in USD) applied when computing breakpoints. `NULL` means no
-#'       minimum-size screen is applied.
+#'     \item `breakpoints_min_size` (defaults to `NA`): Minimum market-cap
+#'       threshold (in USD) applied when computing breakpoints. `NA` means no
+#'       minimum-size screen is applied. Pass `NULL` to remove this filter
+#'       entirely and include all portfolios regardless of size screen.
 #'     \item `weighting_scheme` (defaults to `"VW"`): Return weighting within
 #'       portfolios: `"VW"` for value-weighted or `"EW"` for equal-weighted.
 #'   }
@@ -259,9 +260,9 @@ check_supported_dataset_huggingface <- function(dataset) {
 #'     \item{`rebalancing`}{`"monthly"`}
 #'     \item{`breakpoints_main`}{`10`}
 #'     \item{`sorting_method`}{`"univariate"`}
-#'     \item{`breakpoints_secondary`}{`NULL`}
+#'     \item{`breakpoints_secondary`}{`NA` for univariate sorts; required otherwise}
 #'     \item{`breakpoints_exchanges`}{`"NYSE"`}
-#'     \item{`breakpoints_min_size`}{`NULL`}
+#'     \item{`breakpoints_min_size`}{`NA`}
 #'     \item{`weighting_scheme`}{`"VW"`}
 #'   }
 #'   Each value can be a vector to match multiple levels.
@@ -287,7 +288,7 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
     sorting_method = "univariate",
     breakpoints_secondary = NULL,
     breakpoints_exchanges = "NYSE",
-    breakpoints_min_size = NULL,
+    breakpoints_min_size = NA_real_,
     weighting_scheme = "VW"
   )
 
@@ -306,6 +307,17 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
         filters[col] <- list(defaults[[col]])
       }
     }
+
+    if (is.null(filters[["breakpoints_secondary"]])) {
+      sorting_methods <- filters[["sorting_method"]]
+      if (!all(sorting_methods == "univariate")) {
+        cli::cli_abort(c(
+          "{.arg breakpoints_secondary} must be specified for bivariate sorts.",
+          "i" = "Provide a value for {.arg breakpoints_secondary} or use {.code fill_all = TRUE} to skip all defaults."
+        ))
+      }
+      filters["breakpoints_secondary"] <- list(NA_real_)
+    }
   }
 
   result <- get_available_huggingface_files(
@@ -318,7 +330,7 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
       sorting_variable = stringr::str_replace(.data$sorting_variable, "sv_", "")
     )
 
-  filters <- lapply(filters, function(x) if (is.null(x)) NA_real_ else x)
+  filters <- Filter(Negate(is.null), filters)
 
   for (col in names(filters)) {
     result <- dplyr::filter(result, .data[[col]] %in% filters[[col]])

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -330,7 +330,7 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
       sorting_variable = stringr::str_replace(.data$sorting_variable, "sv_", "")
     )
 
-  filters <- Filter(Negate(is.null), filters)
+  filters <- purrr::compact(filters)
 
   for (col in names(filters)) {
     result <- dplyr::filter(result, .data[[col]] %in% filters[[col]])

--- a/man/download_data_huggingface.Rd
+++ b/man/download_data_huggingface.Rd
@@ -29,9 +29,11 @@ the portfolio grid. Each argument takes the form \code{column = value}, where
 \code{value} may be a vector to match multiple levels. Optionally pass
 \code{fill_all = TRUE} to leave unspecified columns unrestricted (default:
 \code{FALSE}, i.e. unspecified columns are fixed at the defaults listed below).
-Passing an unrecognised column name raises an error listing the supported
-names. Ignored when \code{dataset != "factor_library"}. See the Details section
-for supported columns and their defaults.}
+Passing \code{NULL} for any parameter removes that filter entirely, returning
+all values for that column (e.g., \code{exclude_size = NULL} includes all size
+groups). Passing an unrecognised column name raises an error listing the
+supported names. Ignored when \code{dataset != "factor_library"}. See the
+Details section for supported columns and their defaults.}
 }
 \value{
 A tibble with the downloaded data. For \code{"high_frequency_sp500"},
@@ -75,16 +77,18 @@ are reformed: \code{"monthly"} or \code{"annual"}.
 \item \code{sorting_method} (defaults to \code{"univariate"}): Whether portfolios
 are formed on a single sort (\code{"univariate"}) or a sequential double
 sort (\code{"sequential"}).
-\item \code{breakpoints_secondary} (defaults to \code{NA} for univariate sorts):
-Number of groups for the secondary sort variable. Required when
-\code{sorting_method} is not \code{"univariate"}.
+\item \code{breakpoints_secondary} (defaults to \code{NULL}; treated as \code{NA} for
+univariate sorts): Number of groups for the secondary sort variable.
+Required when \code{sorting_method} is not \code{"univariate"}. Note: explicitly
+passing \code{NA} with a non-univariate \code{sorting_method} is not equivalent
+to the default — it bypasses the validation and filters to portfolios
+where \code{breakpoints_secondary} is \code{NA}, likely returning no results.
 \item \code{breakpoints_exchanges} (defaults to: \code{"NYSE"}): Exchange(s) used
 to compute breakpoints. \code{"NYSE"} uses only NYSE-listed stocks to
 define quantile cutoffs (the conventional Fama-French approach).
 \item \code{breakpoints_min_size} (defaults to \code{NA}): Minimum market-cap
 threshold (in USD) applied when computing breakpoints. \code{NA} means no
-minimum-size screen is applied. Pass \code{NULL} to remove this filter
-entirely and include all portfolios regardless of size screen.
+minimum-size screen is applied.
 \item \code{weighting_scheme} (defaults to \code{"VW"}): Return weighting within
 portfolios: \code{"VW"} for value-weighted or \code{"EW"} for equal-weighted.
 }

--- a/man/download_data_huggingface.Rd
+++ b/man/download_data_huggingface.Rd
@@ -75,15 +75,16 @@ are reformed: \code{"monthly"} or \code{"annual"}.
 \item \code{sorting_method} (defaults to \code{"univariate"}): Whether portfolios
 are formed on a single sort (\code{"univariate"}) or a sequential double
 sort (\code{"sequential"}).
-\item \code{breakpoints_secondary} (defaults to \code{NA}): Number of groups for
-the secondary sort variable; only relevant when
-\code{sorting_method = "sequential"}.
+\item \code{breakpoints_secondary} (defaults to \code{NA} for univariate sorts):
+Number of groups for the secondary sort variable. Required when
+\code{sorting_method} is not \code{"univariate"}.
 \item \code{breakpoints_exchanges} (defaults to: \code{"NYSE"}): Exchange(s) used
 to compute breakpoints. \code{"NYSE"} uses only NYSE-listed stocks to
 define quantile cutoffs (the conventional Fama-French approach).
 \item \code{breakpoints_min_size} (defaults to \code{NA}): Minimum market-cap
 threshold (in USD) applied when computing breakpoints. \code{NA} means no
-minimum-size screen is applied.
+minimum-size screen is applied. Pass \code{NULL} to remove this filter
+entirely and include all portfolios regardless of size screen.
 \item \code{weighting_scheme} (defaults to \code{"VW"}): Return weighting within
 portfolios: \code{"VW"} for value-weighted or \code{"EW"} for equal-weighted.
 }

--- a/tests/testthat/test-download_data_huggingface.R
+++ b/tests/testthat/test-download_data_huggingface.R
@@ -109,8 +109,8 @@ test_that(
 
 test_that(
   paste(
-    "filter_factor_library_grid(): explicit NULL equals omitted argument",
-    "and neither returns empty results"
+    "filter_factor_library_grid(): omitted breakpoints_min_size defaults to",
+    "NA (standard portfolio); explicit NULL removes the filter"
   ),
   {
     grid_rows <- tibble::tibble(
@@ -143,8 +143,8 @@ test_that(
           breakpoints_min_size = NULL
         )
 
-        expect_identical(ids_default, ids_explicit_null)
         expect_length(ids_default, 1L)
+        expect_length(ids_explicit_null, 2L)
       }
     )
   }

--- a/tests/testthat/test-download_data_huggingface.R
+++ b/tests/testthat/test-download_data_huggingface.R
@@ -105,6 +105,51 @@ test_that(
   }
 )
 
+# NULL default / explicit NULL behaviour (mocked) ----------------------
+
+test_that(
+  paste(
+    "filter_factor_library_grid(): explicit NULL equals omitted argument",
+    "and neither returns empty results"
+  ),
+  {
+    grid_rows <- tibble::tibble(
+      id = c(1L, 2L),
+      sorting_variable = c("sv_bm", "sv_bm"),
+      exclude_size = c(0.2, 0.2),
+      exclude_financials = c(FALSE, FALSE),
+      exclude_utilities = c(FALSE, FALSE),
+      exclude_negative_earnings = c(FALSE, FALSE),
+      sorting_variable_lag = c("6m", "6m"),
+      rebalancing = c("monthly", "monthly"),
+      breakpoints_main = c(10L, 10L),
+      sorting_method = c("univariate", "univariate"),
+      breakpoints_secondary = c(NA_real_, NA_real_),
+      breakpoints_exchanges = c("NYSE", "NYSE"),
+      breakpoints_min_size = c(NA_real_, 1e9),
+      weighting_scheme = c("VW", "VW")
+    )
+
+    mock_files <- function(organization, dataset) {
+      make_grid_parquet_file(grid_rows)
+    }
+
+    with_mocked_bindings(
+      get_available_huggingface_files = mock_files,
+      {
+        ids_default <- filter_factor_library_grid(sorting_variable = "bm")
+        ids_explicit_null <- filter_factor_library_grid(
+          sorting_variable = "bm",
+          breakpoints_min_size = NULL
+        )
+
+        expect_identical(ids_default, ids_explicit_null)
+        expect_length(ids_default, 2L)
+      }
+    )
+  }
+)
+
 # Successful download (mocked) ------------------------------------------
 
 test_that(

--- a/tests/testthat/test-download_data_huggingface.R
+++ b/tests/testthat/test-download_data_huggingface.R
@@ -144,7 +144,7 @@ test_that(
         )
 
         expect_identical(ids_default, ids_explicit_null)
-        expect_length(ids_default, 2L)
+        expect_length(ids_default, 1L)
       }
     )
   }


### PR DESCRIPTION
## Summary

- Changes `breakpoints_secondary` and `breakpoints_min_size` defaults from `NA_real_` to `NULL` in `filter_factor_library_grid()`, consistent with `breakpoint_options()` and the principle that optional filters should be absent (`NULL`) rather than a missing numeric (`NA`)
- Updates all three documentation locations (two `@param` blocks and the defaults list)
- No other code changes needed: in R, assigning `NULL` to a named list element removes it, so the filter loop naturally skips these columns when the default is used

Closes #209

## Test plan

- [ ] Verify `filter_factor_library_grid(sorting_variable = "bm")` still returns the same IDs as before (univariate, NYSE, monthly, decile defaults still applied via `sorting_method = "univariate"`)
- [ ] Verify `filter_factor_library_grid(sorting_variable = "bm", fill_all = TRUE)` is unaffected
- [ ] Verify passing an explicit `breakpoints_secondary = NA` still filters correctly for rows where the grid column is `NA`

