### PR TITLE
`join_lagged_values()` fails if column exists in both data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.4.5.9024
+Version: 0.4.5.9025
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/R/join_lagged_values.R
+++ b/R/join_lagged_values.R
@@ -114,6 +114,21 @@ join_lagged_values <- function(
     )
   }
 
+  original_non_key_cols <- setdiff(names(original_data), c(id_keys, id_date))
+  duplicate_cols <- intersect(new_column_names, original_non_key_cols)
+  if (length(duplicate_cols) > 0) {
+    cli::cli_abort(
+      c(
+        "Column{?s} in {.arg new_data} already exist in {.arg original_data}.",
+        "i" = "Duplicate column{?s}: {.field {duplicate_cols}}.",
+        "i" = paste0(
+          "Remove or rename {?this column/these columns} ",
+          "from {.arg new_data} before joining."
+        )
+      )
+    )
+  }
+
   new_data <- new_data |>
     check_new_col(c(".lower", ".upper")) |>
     dplyr::mutate(

--- a/R/join_lagged_values.R
+++ b/R/join_lagged_values.R
@@ -119,9 +119,16 @@ join_lagged_values <- function(
   if (length(duplicate_cols) > 0) {
     cli::cli_abort(
       c(
-        "Column{?s} in {.arg new_data} already exist in {.arg original_data}.",
-        "i" = "Duplicate column{?s}: {.field {duplicate_cols}}.",
+        paste0(
+          "{cli::qty(length(duplicate_cols))}Column{?s} in {.arg new_data} ",
+          "already exist in {.arg original_data}."
+        ),
+        "x" = paste0(
+          "{cli::qty(length(duplicate_cols))}",
+          "Duplicate column{?s}: {.field {duplicate_cols}}."
+        ),
         "i" = paste0(
+          "{cli::qty(length(duplicate_cols))}",
           "Remove or rename {?this column/these columns} ",
           "from {.arg new_data} before joining."
         )

--- a/tests/testthat/test-join_lagged_values.R
+++ b/tests/testthat/test-join_lagged_values.R
@@ -163,30 +163,36 @@ test_that("ff_adjustment picks latest date per year", {
   expect_equal(result$x[1], 20)
 })
 
-test_that("input validation: duplicate columns between new_data and original_data", {
-  df1 <- tibble(
-    id = rep(1, 3),
-    date = as.Date(c("2020-02-01", "2020-03-01", "2020-04-01")),
-    bm = runif(3)
-  )
+test_that(
+  paste0(
+    "input validation: duplicate columns between ",
+    "new_data and original_data"
+  ),
+  {
+    df1 <- tibble(
+      id = rep(1, 3),
+      date = as.Date(c("2020-02-01", "2020-03-01", "2020-04-01")),
+      bm = runif(3)
+    )
 
-  df2 <- tibble(
-    id = rep(1, 3),
-    date = as.Date(c("2020-01-01", "2020-02-01", "2020-03-01")),
-    bm = runif(3)
-  )
+    df2 <- tibble(
+      id = rep(1, 3),
+      date = as.Date(c("2020-01-01", "2020-02-01", "2020-03-01")),
+      bm = runif(3)
+    )
 
-  expect_error(
-    join_lagged_values(
-      df1,
-      df2,
-      id_keys = "id",
-      min_lag = months(1),
-      max_lag = months(3)
-    ),
-    regexp = "already exist.*original_data.*bm"
-  )
-})
+    expect_error(
+      join_lagged_values(
+        df1,
+        df2,
+        id_keys = "id",
+        min_lag = months(1),
+        max_lag = months(3)
+      ),
+      regexp = "already exist.*original_data.*bm"
+    )
+  }
+)
 
 test_that("input validation: id_keys must be character", {
   df <- tibble(id = 1, date = as.Date("2020-01-01"))

--- a/tests/testthat/test-join_lagged_values.R
+++ b/tests/testthat/test-join_lagged_values.R
@@ -163,6 +163,31 @@ test_that("ff_adjustment picks latest date per year", {
   expect_equal(result$x[1], 20)
 })
 
+test_that("input validation: duplicate columns between new_data and original_data", {
+  df1 <- tibble(
+    id = rep(1, 3),
+    date = as.Date(c("2020-02-01", "2020-03-01", "2020-04-01")),
+    bm = runif(3)
+  )
+
+  df2 <- tibble(
+    id = rep(1, 3),
+    date = as.Date(c("2020-01-01", "2020-02-01", "2020-03-01")),
+    bm = runif(3)
+  )
+
+  expect_error(
+    join_lagged_values(
+      df1,
+      df2,
+      id_keys = "id",
+      min_lag = months(1),
+      max_lag = months(3)
+    ),
+    regexp = "already exist.*original_data.*bm"
+  )
+})
+
 test_that("input validation: id_keys must be character", {
   df <- tibble(id = 1, date = as.Date("2020-01-01"))
   expect_error(


### PR DESCRIPTION
Related to #220.

- [x] Add a warning
- [x] Add test for it
- [x] Documentation, lint, and version number