### PR TITLE
Estimate_model-behaviour-when-a-rolling-window-has-enough-rows-but-all-have-NAs-in-the-model-variables

### DIFF
--- a/R/estimate_model.R
+++ b/R/estimate_model.R
@@ -106,26 +106,27 @@ estimate_model <- function(data, model, min_obs = 1, output = "coefficients") {
   needs_coefficients <- "coefficients" %in% output
   needs_tstats <- "tstats" %in% output
 
+  complete <- stats::complete.cases(stats::model.frame(
+    formula,
+    data = data,
+    na.action = stats::na.pass
+  ))
+
   if (needs_residuals) {
-    complete <- stats::complete.cases(stats::model.frame(
-      formula,
-      data = data,
-      na.action = stats::na.pass
-    ))
     insufficient_residuals <- sum(complete) < min_obs ||
       sum(complete) <= length(independent_vars)
   }
 
   if (needs_coefficients || needs_tstats) {
-    insufficient_summary <- nrow(data) < min_obs ||
-      nrow(data) <= length(independent_vars)
+    insufficient_summary <- sum(complete) < min_obs ||
+      sum(complete) <= length(independent_vars)
   }
 
   fit <- NULL
   if (needs_residuals && !insufficient_residuals) {
     fit <- stats::lm(formula, data = data[complete, ])
   } else if ((needs_coefficients || needs_tstats) && !insufficient_summary) {
-    fit <- stats::lm(formula, data = data)
+    fit <- stats::lm(formula, data = data[complete, ])
   }
 
   to_tibble <- function(x) {

--- a/R/estimate_model.R
+++ b/R/estimate_model.R
@@ -112,20 +112,19 @@ estimate_model <- function(data, model, min_obs = 1, output = "coefficients") {
     na.action = stats::na.pass
   ))
 
+  insufficient <- sum(complete) < min_obs ||
+    sum(complete) <= length(independent_vars)
+
   if (needs_residuals) {
-    insufficient_residuals <- sum(complete) < min_obs ||
-      sum(complete) <= length(independent_vars)
+    insufficient_residuals <- insufficient
   }
 
   if (needs_coefficients || needs_tstats) {
-    insufficient_summary <- sum(complete) < min_obs ||
-      sum(complete) <= length(independent_vars)
+    insufficient_summary <- insufficient
   }
 
   fit <- NULL
-  if (needs_residuals && !insufficient_residuals) {
-    fit <- stats::lm(formula, data = data[complete, ])
-  } else if ((needs_coefficients || needs_tstats) && !insufficient_summary) {
+  if (!insufficient) {
     fit <- stats::lm(formula, data = data[complete, ])
   }
 

--- a/R/estimate_model.R
+++ b/R/estimate_model.R
@@ -115,14 +115,6 @@ estimate_model <- function(data, model, min_obs = 1, output = "coefficients") {
   insufficient <- sum(complete) < min_obs ||
     sum(complete) <= length(independent_vars)
 
-  if (needs_residuals) {
-    insufficient_residuals <- insufficient
-  }
-
-  if (needs_coefficients || needs_tstats) {
-    insufficient_summary <- insufficient
-  }
-
   fit <- NULL
   if (!insufficient) {
     fit <- stats::lm(formula, data = data[complete, ])
@@ -146,7 +138,7 @@ estimate_model <- function(data, model, min_obs = 1, output = "coefficients") {
   result <- list()
 
   if (needs_coefficients) {
-    if (insufficient_summary) {
+    if (insufficient) {
       result$coefficients <- na_tibble()
     } else {
       result$coefficients <- to_tibble(stats::coef(fit))
@@ -154,7 +146,7 @@ estimate_model <- function(data, model, min_obs = 1, output = "coefficients") {
   }
 
   if (needs_tstats) {
-    if (insufficient_summary) {
+    if (insufficient) {
       result$tstats <- na_tibble()
     } else {
       result$tstats <- to_tibble(summary(fit)$coefficients[, "t value"])
@@ -162,7 +154,7 @@ estimate_model <- function(data, model, min_obs = 1, output = "coefficients") {
   }
 
   if (needs_residuals) {
-    if (insufficient_residuals) {
+    if (insufficient) {
       result$residuals <- rep(NA_real_, nrow(data))
     } else {
       resid_result <- rep(NA_real_, nrow(data))

--- a/tests/testthat/test-estimate_model.R
+++ b/tests/testthat/test-estimate_model.R
@@ -198,3 +198,25 @@ test_that("residuals are NA when too few complete cases after NA removal", {
   )
   expect_true(all(is.na(result)))
 })
+
+test_that("coefficients are NA tibble when all model rows are NA (regression: lm.fit 0 cases)", {
+  all_na <- test_data
+  all_na$ret_excess[] <- NA
+  expect_no_error(
+    result <- estimate_model(all_na, "ret_excess ~ mkt_excess", min_obs = 1)
+  )
+  expect_s3_class(result, "tbl_df")
+  expect_true(all(is.na(result)))
+})
+
+test_that("tstats are NA tibble when all model rows are NA", {
+  all_na <- test_data
+  all_na$ret_excess[] <- NA
+  expect_no_error(
+    result <- estimate_model(
+      all_na, "ret_excess ~ mkt_excess", min_obs = 1, output = "tstats"
+    )
+  )
+  expect_s3_class(result, "tbl_df")
+  expect_true(all(is.na(result)))
+})

--- a/tests/testthat/test-estimate_model.R
+++ b/tests/testthat/test-estimate_model.R
@@ -199,7 +199,7 @@ test_that("residuals are NA when too few complete cases after NA removal", {
   expect_true(all(is.na(result)))
 })
 
-test_that("coefficients are NA tibble when all model rows are NA (regression: lm.fit 0 cases)", {
+test_that("coefficients are NA when all rows are NA", {
   all_na <- test_data
   all_na$ret_excess[] <- NA
   expect_no_error(

--- a/tests/testthat/test-estimate_model.R
+++ b/tests/testthat/test-estimate_model.R
@@ -214,7 +214,10 @@ test_that("tstats are NA tibble when all model rows are NA", {
   all_na$ret_excess[] <- NA
   expect_no_error(
     result <- estimate_model(
-      all_na, "ret_excess ~ mkt_excess", min_obs = 1, output = "tstats"
+      all_na,
+      "ret_excess ~ mkt_excess",
+      min_obs = 1,
+      output = "tstats"
     )
   )
   expect_s3_class(result, "tbl_df")


### PR DESCRIPTION
Currently estimate_betas() throws an error when receiving at least one rolling window with zero complete rows. Replaced this with an NA. 