### PR TITLE
Apply min_portfolio_size to reported cross-section in bivariate sorts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 
 - Removed erroneous time zone adjustment in `download_data_wrds_trace_enhanced()` [#133](https://github.com/tidy-finance/r-tidyfinance/issues/133). 
 - Replaced tabs in `list_supported_types_ff()` with underscores [#134](https://github.com/tidy-finance/r-tidyfinance/issues/134).
+- `compute_portfolio_returns()` and `implement_portfolio_sort()` now apply `min_portfolio_size` to the reported portfolio cross-section. For bivariate sorts this is the firm count per `(main_portfolio, date)` summed across secondary buckets, not per `(main, secondary, date)` cell as before. Previously, setting `min_portfolio_size` to the number of cells (e.g. `n_main * n_secondary`) silently voided every cell. Univariate behaviour is unchanged. The param documentation has also been corrected to reflect that small portfolios receive `NA` (not zero).
 
 # tidyfinance 0.4.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
 
 - Removed erroneous time zone adjustment in `download_data_wrds_trace_enhanced()` [#133](https://github.com/tidy-finance/r-tidyfinance/issues/133). 
 - Replaced tabs in `list_supported_types_ff()` with underscores [#134](https://github.com/tidy-finance/r-tidyfinance/issues/134).
-- `compute_portfolio_returns()` and `implement_portfolio_sort()` now apply `min_portfolio_size` to the reported portfolio cross-section. For bivariate sorts this is the firm count per `(main_portfolio, date)` summed across secondary buckets, not per `(main, secondary, date)` cell as before. Previously, setting `min_portfolio_size` to the number of cells (e.g. `n_main * n_secondary`) silently voided every cell. Univariate behaviour is unchanged. The param documentation has also been corrected to reflect that small portfolios receive `NA` (not zero).
+- `compute_portfolio_returns()` and `implement_portfolio_sort()` now apply `min_portfolio_size` to the reported portfolio cross-section. For bivariate sorts this is the firm count per `(main_portfolio, date)` summed across secondary buckets, not per `(main, secondary, date)` cell as before. Previously, setting `min_portfolio_size` to the number of cells (e.g. `n_main * n_secondary`) silently voided every cell. Univariate behaviour is unchanged. The default has changed from `0L` to `1L`, so each reported portfolio is required to have at least one observation by default; pass `min_portfolio_size = 0L` to deactivate the check. The param documentation has also been corrected to reflect that small portfolios receive `NA` (not zero).
 
 # tidyfinance 0.4.5
 

--- a/R/compute_portfolio_returns.R
+++ b/R/compute_portfolio_returns.R
@@ -632,16 +632,21 @@ aggregate_bivariate_returns <- function(
     ) |>
     dplyr::left_join(
       n_per_main_date,
-      by = stats::setNames(c("portfolio_main", date_col), c("portfolio", date_col))
+      by = stats::setNames(
+        c("portfolio_main", date_col),
+        c("portfolio", date_col)
+      )
     ) |>
     dplyr::mutate(
       dplyr::across(
         c(ret_excess_vw, ret_excess_ew, ret_excess_vw_capped),
-        \(x) dplyr::if_else(
-          is.nan(x) | is.na(n_firms) | n_firms < min_portfolio_size,
-          NA_real_,
-          x
-        )
+        \(x) {
+          dplyr::if_else(
+            is.nan(x) | is.na(n_firms) | n_firms < min_portfolio_size,
+            NA_real_,
+            x
+          )
+        }
       )
     ) |>
     dplyr::select(-n_firms)

--- a/R/compute_portfolio_returns.R
+++ b/R/compute_portfolio_returns.R
@@ -54,13 +54,14 @@
 #'   [compute_breakpoints()].
 #' @param min_portfolio_size An integer specifying the minimum number of
 #'   firms required in the reported portfolio cross-section on a given date
-#'   (default is `0L`, no minimum). For both univariate and bivariate sorts
-#'   the threshold is applied to the firm count per `(portfolio, date)` of
-#'   the reported cross-section: for univariate sorts that is firms per
-#'   portfolio-date; for bivariate sorts that is firms per main-portfolio-date
-#'   summed across the secondary buckets. Cross-sections below the threshold
-#'   have their returns set to `NA`. A typical value is `5L` (the Fama-French
-#'   convention).
+#'   (default `1L`, i.e. at least one observation per reported portfolio).
+#'   For both univariate and bivariate sorts the threshold is applied to the
+#'   firm count per `(portfolio, date)` of the reported cross-section: for
+#'   univariate sorts that is firms per portfolio-date; for bivariate sorts
+#'   that is firms per main-portfolio-date summed across the secondary
+#'   buckets. Cross-sections below the threshold have their returns set to
+#'   `NA`. A typical value is `5L` (the Fama-French convention). Set to `0L`
+#'   to deactivate the check entirely.
 #' @param cap_weight A numeric value between 0 and 1 specifying the percentile
 #'   at which market capitalization is capped per date when computing capped
 #'   value-weighted excess returns (i.e., `ret_excess_vw_capped`). Defaults to
@@ -143,7 +144,7 @@ compute_portfolio_returns <- function(
   breakpoint_options_secondary = NULL,
   breakpoint_function_main = compute_breakpoints,
   breakpoint_function_secondary = compute_breakpoints,
-  min_portfolio_size = 0L,
+  min_portfolio_size = 1L,
   cap_weight = 0.8,
   data_options = NULL,
   quiet = FALSE
@@ -637,7 +638,7 @@ aggregate_bivariate_returns <- function(
       dplyr::across(
         c(ret_excess_vw, ret_excess_ew, ret_excess_vw_capped),
         \(x) dplyr::if_else(
-          is.nan(x) | n_firms < min_portfolio_size,
+          is.nan(x) | is.na(n_firms) | n_firms < min_portfolio_size,
           NA_real_,
           x
         )

--- a/R/compute_portfolio_returns.R
+++ b/R/compute_portfolio_returns.R
@@ -53,8 +53,14 @@
 #'   for the secondary sorting variable. The default is set to
 #'   [compute_breakpoints()].
 #' @param min_portfolio_size An integer specifying the minimum number of
-#'   portfolio constituents (default is set to `0`, effectively deactivating
-#'   the check). Small portfolios' returns are set to zero.
+#'   firms required in the reported portfolio cross-section on a given date
+#'   (default is `0L`, no minimum). For both univariate and bivariate sorts
+#'   the threshold is applied to the firm count per `(portfolio, date)` of
+#'   the reported cross-section: for univariate sorts that is firms per
+#'   portfolio-date; for bivariate sorts that is firms per main-portfolio-date
+#'   summed across the secondary buckets. Cross-sections below the threshold
+#'   have their returns set to `NA`. A typical value is `5L` (the Fama-French
+#'   convention).
 #' @param cap_weight A numeric value between 0 and 1 specifying the percentile
 #'   at which market capitalization is capped per date when computing capped
 #'   value-weighted excess returns (i.e., `ret_excess_vw_capped`). Defaults to
@@ -400,22 +406,14 @@ compute_portfolio_returns <- function(
       )
     }
 
-    portfolio_returns <- portfolio_returns |>
-      dplyr::group_by(portfolio_main, portfolio_secondary, .data[[date_col]]) |>
-      summarise_portfolio_returns(
-        ret_col,
-        w_col,
-        w_capped_col,
-        min_portfolio_size
-      ) |>
-      dplyr::group_by(portfolio = portfolio_main, .data[[date_col]]) |>
-      dplyr::summarise(
-        dplyr::across(
-          c(ret_excess_vw, ret_excess_ew, ret_excess_vw_capped),
-          \(x) mean(x, na.rm = TRUE)
-        ),
-        .groups = "drop"
-      )
+    portfolio_returns <- aggregate_bivariate_returns(
+      portfolio_returns,
+      date_col,
+      ret_col,
+      w_col,
+      w_capped_col,
+      min_portfolio_size
+    )
   }
 
   if (sorting_method == "bivariate-independent") {
@@ -481,22 +479,14 @@ compute_portfolio_returns <- function(
       )
     }
 
-    portfolio_returns <- portfolio_returns |>
-      dplyr::group_by(portfolio_main, portfolio_secondary, .data[[date_col]]) |>
-      summarise_portfolio_returns(
-        ret_col,
-        w_col,
-        w_capped_col,
-        min_portfolio_size
-      ) |>
-      dplyr::group_by(portfolio = portfolio_main, .data[[date_col]]) |>
-      dplyr::summarise(
-        dplyr::across(
-          c(ret_excess_vw, ret_excess_ew, ret_excess_vw_capped),
-          \(x) mean(x, na.rm = TRUE)
-        ),
-        .groups = "drop"
-      )
+    portfolio_returns <- aggregate_bivariate_returns(
+      portfolio_returns,
+      date_col,
+      ret_col,
+      w_col,
+      w_capped_col,
+      min_portfolio_size
+    )
   }
 
   portfolio_returns <- portfolio_returns[!is.na(portfolio_returns$portfolio), ]
@@ -538,7 +528,8 @@ compute_portfolio_returns <- function(
       paste0(
         "Returning a complete panel with {n_missing} missing value{?s} ",
         "in factor returns due to insufficient observations ",
-        "(n() <= {min_portfolio_size})."
+        "(fewer than {min_portfolio_size} firm{?s} per (portfolio, date) ",
+        "cross-section)."
       )
     )
   }
@@ -589,6 +580,70 @@ summarise_portfolio_returns <- function(
       ),
       .groups = "drop"
     )
+}
+
+#' Aggregate bivariate-sort returns across the secondary dimension
+#'
+#' Computes cell-level returns over `(portfolio_main, portfolio_secondary,
+#' date)` without an occupancy threshold, then averages across the secondary
+#' buckets to obtain reported `(portfolio_main, date)` returns. The
+#' `min_portfolio_size` threshold is applied to the per-`(portfolio_main,
+#' date)` firm count (the reported cross-section), not per cell.
+#'
+#' @param portfolio_returns A panel with columns `portfolio_main`,
+#'   `portfolio_secondary`, the date column, and per-stock returns/weights.
+#' @param date_col,ret_col,w_col,w_capped_col Column names.
+#' @param min_portfolio_size Minimum firms per reported `(portfolio_main,
+#'   date)` cross-section. Cross-sections below this size receive `NA`.
+#'
+#' @returns A data frame with columns `portfolio`, the date column, and the
+#'   three return columns.
+#'
+#' @keywords internal
+#' @noRd
+aggregate_bivariate_returns <- function(
+  portfolio_returns,
+  date_col,
+  ret_col,
+  w_col,
+  w_capped_col,
+  min_portfolio_size
+) {
+  n_per_main_date <- portfolio_returns |>
+    dplyr::filter(!is.na(portfolio_main), !is.na(portfolio_secondary)) |>
+    dplyr::count(portfolio_main, .data[[date_col]], name = "n_firms")
+
+  portfolio_returns |>
+    dplyr::group_by(portfolio_main, portfolio_secondary, .data[[date_col]]) |>
+    summarise_portfolio_returns(
+      ret_col,
+      w_col,
+      w_capped_col,
+      min_portfolio_size = 0L
+    ) |>
+    dplyr::group_by(portfolio = portfolio_main, .data[[date_col]]) |>
+    dplyr::summarise(
+      dplyr::across(
+        c(ret_excess_vw, ret_excess_ew, ret_excess_vw_capped),
+        \(x) mean(x, na.rm = TRUE)
+      ),
+      .groups = "drop"
+    ) |>
+    dplyr::left_join(
+      n_per_main_date,
+      by = stats::setNames(c("portfolio_main", date_col), c("portfolio", date_col))
+    ) |>
+    dplyr::mutate(
+      dplyr::across(
+        c(ret_excess_vw, ret_excess_ew, ret_excess_vw_capped),
+        \(x) dplyr::if_else(
+          is.nan(x) | n_firms < min_portfolio_size,
+          NA_real_,
+          x
+        )
+      )
+    ) |>
+    dplyr::select(-n_firms)
 }
 
 #' Join rebalanced portfolio assignments to sorting data (internal helper)

--- a/R/global_variables.R
+++ b/R/global_variables.R
@@ -227,6 +227,7 @@ utils::globalVariables(
     "listing_age",
     "first_crsp_date",
     ".size_cutoff",
-    "ib"
+    "ib",
+    "n_firms"
   )
 )

--- a/R/implement_portfolio_sort.R
+++ b/R/implement_portfolio_sort.R
@@ -41,10 +41,11 @@
 #'   for the secondary sorting variable. Defaults to [compute_breakpoints()].
 #' @param min_portfolio_size An integer specifying the minimum number of
 #'   firms in the reported portfolio cross-section on a given date. Defaults
-#'   to `0L` (no minimum). For univariate sorts that is firms per
-#'   portfolio-date; for bivariate sorts that is firms per main-portfolio-date
-#'   summed across the secondary buckets. Cross-sections below the threshold
-#'   have their returns set to `NA`. See [compute_portfolio_returns()].
+#'   to `1L` (at least one observation per reported portfolio). For univariate
+#'   sorts that is firms per portfolio-date; for bivariate sorts that is firms
+#'   per main-portfolio-date summed across the secondary buckets.
+#'   Cross-sections below the threshold have their returns set to `NA`.
+#'   Set to `0L` to deactivate the check. See [compute_portfolio_returns()].
 #' @param cap_weight A numeric between 0 and 1 specifying the quantile at which
 #'   portfolio weights are capped for the capped value-weighted return.
 #'   Defaults to `0.8`.
@@ -105,7 +106,7 @@ implement_portfolio_sort <- function(
   portfolio_sort_options,
   breakpoint_function_main = compute_breakpoints,
   breakpoint_function_secondary = compute_breakpoints,
-  min_portfolio_size = 0L,
+  min_portfolio_size = 1L,
   cap_weight = 0.8,
   data_options = NULL,
   quiet = FALSE

--- a/R/implement_portfolio_sort.R
+++ b/R/implement_portfolio_sort.R
@@ -39,9 +39,12 @@
 #'   the main sorting variable. Defaults to [compute_breakpoints()].
 #' @param breakpoint_function_secondary The function used to compute breakpoints
 #'   for the secondary sorting variable. Defaults to [compute_breakpoints()].
-#' @param min_portfolio_size An integer specifying the minimum number of stocks
-#'   required in a portfolio. Portfolios with fewer stocks receive `NA` returns.
-#'   Defaults to `0L`.
+#' @param min_portfolio_size An integer specifying the minimum number of
+#'   firms in the reported portfolio cross-section on a given date. Defaults
+#'   to `0L` (no minimum). For univariate sorts that is firms per
+#'   portfolio-date; for bivariate sorts that is firms per main-portfolio-date
+#'   summed across the secondary buckets. Cross-sections below the threshold
+#'   have their returns set to `NA`. See [compute_portfolio_returns()].
 #' @param cap_weight A numeric between 0 and 1 specifying the quantile at which
 #'   portfolio weights are capped for the capped value-weighted return.
 #'   Defaults to `0.8`.

--- a/man/compute_portfolio_returns.Rd
+++ b/man/compute_portfolio_returns.Rd
@@ -65,8 +65,14 @@ for the secondary sorting variable. The default is set to
 \code{\link[=compute_breakpoints]{compute_breakpoints()}}.}
 
 \item{min_portfolio_size}{An integer specifying the minimum number of
-portfolio constituents (default is set to \code{0}, effectively deactivating
-the check). Small portfolios' returns are set to zero.}
+firms required in the reported portfolio cross-section on a given date
+(default is \code{0L}, no minimum). For both univariate and bivariate sorts
+the threshold is applied to the firm count per \verb{(portfolio, date)} of
+the reported cross-section: for univariate sorts that is firms per
+portfolio-date; for bivariate sorts that is firms per main-portfolio-date
+summed across the secondary buckets. Cross-sections below the threshold
+have their returns set to \code{NA}. A typical value is \code{5L} (the Fama-French
+convention).}
 
 \item{cap_weight}{A numeric value between 0 and 1 specifying the percentile
 at which market capitalization is capped per date when computing capped

--- a/man/compute_portfolio_returns.Rd
+++ b/man/compute_portfolio_returns.Rd
@@ -13,7 +13,7 @@ compute_portfolio_returns(
   breakpoint_options_secondary = NULL,
   breakpoint_function_main = compute_breakpoints,
   breakpoint_function_secondary = compute_breakpoints,
-  min_portfolio_size = 0L,
+  min_portfolio_size = 1L,
   cap_weight = 0.8,
   data_options = NULL,
   quiet = FALSE
@@ -66,13 +66,14 @@ for the secondary sorting variable. The default is set to
 
 \item{min_portfolio_size}{An integer specifying the minimum number of
 firms required in the reported portfolio cross-section on a given date
-(default is \code{0L}, no minimum). For both univariate and bivariate sorts
-the threshold is applied to the firm count per \verb{(portfolio, date)} of
-the reported cross-section: for univariate sorts that is firms per
-portfolio-date; for bivariate sorts that is firms per main-portfolio-date
-summed across the secondary buckets. Cross-sections below the threshold
-have their returns set to \code{NA}. A typical value is \code{5L} (the Fama-French
-convention).}
+(default \code{1L}, i.e. at least one observation per reported portfolio).
+For both univariate and bivariate sorts the threshold is applied to the
+firm count per \verb{(portfolio, date)} of the reported cross-section: for
+univariate sorts that is firms per portfolio-date; for bivariate sorts
+that is firms per main-portfolio-date summed across the secondary
+buckets. Cross-sections below the threshold have their returns set to
+\code{NA}. A typical value is \code{5L} (the Fama-French convention). Set to \code{0L}
+to deactivate the check entirely.}
 
 \item{cap_weight}{A numeric value between 0 and 1 specifying the percentile
 at which market capitalization is capped per date when computing capped

--- a/man/implement_portfolio_sort.Rd
+++ b/man/implement_portfolio_sort.Rd
@@ -61,9 +61,12 @@ the main sorting variable. Defaults to \code{\link[=compute_breakpoints]{compute
 \item{breakpoint_function_secondary}{The function used to compute breakpoints
 for the secondary sorting variable. Defaults to \code{\link[=compute_breakpoints]{compute_breakpoints()}}.}
 
-\item{min_portfolio_size}{An integer specifying the minimum number of stocks
-required in a portfolio. Portfolios with fewer stocks receive \code{NA} returns.
-Defaults to \code{0L}.}
+\item{min_portfolio_size}{An integer specifying the minimum number of
+firms in the reported portfolio cross-section on a given date. Defaults
+to \code{0L} (no minimum). For univariate sorts that is firms per
+portfolio-date; for bivariate sorts that is firms per main-portfolio-date
+summed across the secondary buckets. Cross-sections below the threshold
+have their returns set to \code{NA}. See \code{\link[=compute_portfolio_returns]{compute_portfolio_returns()}}.}
 
 \item{cap_weight}{A numeric between 0 and 1 specifying the quantile at which
 portfolio weights are capped for the capped value-weighted return.

--- a/man/implement_portfolio_sort.Rd
+++ b/man/implement_portfolio_sort.Rd
@@ -12,7 +12,7 @@ implement_portfolio_sort(
   portfolio_sort_options,
   breakpoint_function_main = compute_breakpoints,
   breakpoint_function_secondary = compute_breakpoints,
-  min_portfolio_size = 0L,
+  min_portfolio_size = 1L,
   cap_weight = 0.8,
   data_options = NULL,
   quiet = FALSE
@@ -63,10 +63,11 @@ for the secondary sorting variable. Defaults to \code{\link[=compute_breakpoints
 
 \item{min_portfolio_size}{An integer specifying the minimum number of
 firms in the reported portfolio cross-section on a given date. Defaults
-to \code{0L} (no minimum). For univariate sorts that is firms per
-portfolio-date; for bivariate sorts that is firms per main-portfolio-date
-summed across the secondary buckets. Cross-sections below the threshold
-have their returns set to \code{NA}. See \code{\link[=compute_portfolio_returns]{compute_portfolio_returns()}}.}
+to \code{1L} (at least one observation per reported portfolio). For univariate
+sorts that is firms per portfolio-date; for bivariate sorts that is firms
+per main-portfolio-date summed across the secondary buckets.
+Cross-sections below the threshold have their returns set to \code{NA}.
+Set to \code{0L} to deactivate the check. See \code{\link[=compute_portfolio_returns]{compute_portfolio_returns()}}.}
 
 \item{cap_weight}{A numeric between 0 and 1 specifying the quantile at which
 portfolio weights are capped for the capped value-weighted return.

--- a/tests/testthat/test-compute_portfolio_returns.R
+++ b/tests/testthat/test-compute_portfolio_returns.R
@@ -979,3 +979,65 @@ test_that("all-NA mktcap_lag produces NA not NaN for VW returns", {
   # EW returns should still be computed
   expect_false(any(is.na(result$ret_excess_ew)))
 })
+
+test_that("bivariate min_portfolio_size counts firms per main-portfolio-date, not per cell", {
+  # 100 firms x 12 months, 5x5 bivariate -> ~4 firms per cell but ~20 per
+  # main-portfolio-date cross-section. A per-cell threshold of 10 would
+  # void every cell; a per-cross-section threshold of 10 should not.
+  data <- make_panel(n_stocks = 100, n_months = 12)
+  result <- compute_portfolio_returns(
+    data,
+    c("size", "bm"),
+    "bivariate-dependent",
+    breakpoint_options_main = breakpoint_options(n_portfolios = 5),
+    breakpoint_options_secondary = breakpoint_options(n_portfolios = 5),
+    min_portfolio_size = 10L,
+    quiet = TRUE
+  )
+  expect_false(all(is.na(result$ret_excess_ew)))
+  # With ~20 firms per main-portfolio-date, threshold = 10 should keep
+  # essentially all cross-sections.
+  expect_gt(mean(!is.na(result$ret_excess_ew)), 0.9)
+})
+
+test_that("bivariate min_portfolio_size voids cross-sections below threshold", {
+  # 60 firms per date, 6 main x 2 secondary -> ~10 firms per main-portfolio
+  # cross-section (summed across secondaries). A threshold of 50 should
+  # void everything.
+  data <- make_panel(n_stocks = 60, n_months = 12)
+  result <- compute_portfolio_returns(
+    data,
+    c("size", "bm"),
+    "bivariate-independent",
+    breakpoint_options_main = breakpoint_options(n_portfolios = 6),
+    breakpoint_options_secondary = breakpoint_options(n_portfolios = 2),
+    min_portfolio_size = 50L,
+    quiet = TRUE
+  )
+  expect_true(all(is.na(result$ret_excess_ew)))
+})
+
+test_that("univariate min_portfolio_size unchanged: counts firms per portfolio-date", {
+  data <- make_panel(n_stocks = 50, n_months = 12)
+  # 50 firms / 5 portfolios = 10 per portfolio-date. Threshold of 11 should
+  # void everything; threshold of 5 should keep everything.
+  result_high <- compute_portfolio_returns(
+    data,
+    "size",
+    "univariate",
+    breakpoint_options_main = breakpoint_options(n_portfolios = 5),
+    min_portfolio_size = 11L,
+    quiet = TRUE
+  )
+  expect_true(all(is.na(result_high$ret_excess_ew)))
+
+  result_low <- compute_portfolio_returns(
+    data,
+    "size",
+    "univariate",
+    breakpoint_options_main = breakpoint_options(n_portfolios = 5),
+    min_portfolio_size = 5L,
+    quiet = TRUE
+  )
+  expect_false(any(is.na(result_low$ret_excess_ew)))
+})

--- a/tests/testthat/test-compute_portfolio_returns.R
+++ b/tests/testthat/test-compute_portfolio_returns.R
@@ -980,7 +980,7 @@ test_that("all-NA mktcap_lag produces NA not NaN for VW returns", {
   expect_false(any(is.na(result$ret_excess_ew)))
 })
 
-test_that("bivariate min_portfolio_size counts firms per main-portfolio-date, not per cell", {
+test_that("bivariate min_portfolio_size counts per main-portfolio-date", {
   # 100 firms x 12 months, 5x5 bivariate -> ~4 firms per cell but ~20 per
   # main-portfolio-date cross-section. A per-cell threshold of 10 would
   # void every cell; a per-cross-section threshold of 10 should not.
@@ -1017,7 +1017,7 @@ test_that("bivariate min_portfolio_size voids cross-sections below threshold", {
   expect_true(all(is.na(result$ret_excess_ew)))
 })
 
-test_that("univariate min_portfolio_size unchanged: counts firms per portfolio-date", {
+test_that("univariate min_portfolio_size counts firms per portfolio-date", {
   data <- make_panel(n_stocks = 50, n_months = 12)
   # 50 firms / 5 portfolios = 10 per portfolio-date. Threshold of 11 should
   # void everything; threshold of 5 should keep everything.


### PR DESCRIPTION
## Summary

- For bivariate sorts, `min_portfolio_size` previously thresholded each `(portfolio_main, portfolio_secondary, date)` cell. The semantic was undocumented and easy to misuse: setting the parameter to the number of cells (a natural intuition, e.g. `n_main * n_secondary`) silently voided every cell, producing all-NA factor returns with no error.
- The threshold now applies to the firm count of the reported `(main_portfolio, date)` cross-section, summed across secondary buckets — consistent with the univariate semantics.
- Univariate behaviour is unchanged.
- Also corrects the param doc that previously stated small portfolios are set to zero (they are set to `NA`), and rewords the panel-completion `cli_inform` to refer to the reported cross-section.

## What changed

- `compute_portfolio_returns()`: factored the bivariate post-aggregation into a small internal helper `aggregate_bivariate_returns()`. It computes per-cell returns without an occupancy threshold, averages across the secondary dimension, and then applies `min_portfolio_size` to the per-`(main, date)` firm count.
- Roxygen docs in `compute_portfolio_returns()` and `implement_portfolio_sort()` updated.
- Three new tests in `test-compute_portfolio_returns.R` covering the new cross-section semantics for both bivariate methods and confirming univariate behaviour.
- NEWS entry under Bug fixes.

## Test plan

- [x] `devtools::test()` — 662 / 662 pass
- [x] `devtools::document()` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)