### PR TITLE
Return NA from compute_long_short_returns on single-portfolio panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 - Removed erroneous time zone adjustment in `download_data_wrds_trace_enhanced()` [#133](https://github.com/tidy-finance/r-tidyfinance/issues/133). 
 - Replaced tabs in `list_supported_types_ff()` with underscores [#134](https://github.com/tidy-finance/r-tidyfinance/issues/134).
 - `compute_portfolio_returns()` and `implement_portfolio_sort()` now apply `min_portfolio_size` to the reported portfolio cross-section. For bivariate sorts this is the firm count per `(main_portfolio, date)` summed across secondary buckets, not per `(main, secondary, date)` cell as before. Previously, setting `min_portfolio_size` to the number of cells (e.g. `n_main * n_secondary`) silently voided every cell. Univariate behaviour is unchanged. The default has changed from `0L` to `1L`, so each reported portfolio is required to have at least one observation by default; pass `min_portfolio_size = 0L` to deactivate the check. The param documentation has also been corrected to reflect that small portfolios receive `NA` (not zero).
+- `compute_long_short_returns()` no longer errors with `object 'top' not found` when the input panel contains only one distinct portfolio (e.g., because `assign_portfolio()` collapsed to a single bucket on a constant sorting variable). The long-short return is now `NA` on such dates, consistent with "no investment, no return", instead of crashing.
 
 # tidyfinance 0.4.5
 

--- a/R/compute_long_short_returns.R
+++ b/R/compute_long_short_returns.R
@@ -72,10 +72,14 @@ compute_long_short_returns <- function(
         )
     ) |>
     mutate(
-      "{data_options$portfolio}" := if_else(
-        .data[[data_options$portfolio]] == min(.data[[data_options$portfolio]]),
-        "bottom",
-        "top"
+      "{data_options$portfolio}" := factor(
+        if_else(
+          .data[[data_options$portfolio]] ==
+            min(.data[[data_options$portfolio]]),
+          "bottom",
+          "top"
+        ),
+        levels = c("bottom", "top")
       )
     ) |>
     ungroup() |>
@@ -84,7 +88,11 @@ compute_long_short_returns <- function(
       names_to = "ret_measure",
       values_to = "ret"
     ) |>
-    tidyr::pivot_wider(names_from = portfolio, values_from = ret) |>
+    tidyr::pivot_wider(
+      names_from = portfolio,
+      values_from = ret,
+      names_expand = TRUE
+    ) |>
     check_new_col("long_short_return") |>
     mutate(
       long_short_return = (top - bottom) *

--- a/tests/testthat/test-compute_long_short_returns.R
+++ b/tests/testthat/test-compute_long_short_returns.R
@@ -1,0 +1,55 @@
+make_portfolio_panel <- function(
+  n_portfolios = 5L,
+  n_months = 12L,
+  seed = 42L
+) {
+  set.seed(seed)
+  dates <- seq.Date(
+    from = as.Date("2020-01-01"),
+    by = "month",
+    length.out = n_months
+  )
+  expand.grid(portfolio = seq_len(n_portfolios), date = dates) |>
+    dplyr::mutate(
+      ret_excess_ew = rnorm(dplyr::n(), 0, 0.05),
+      ret_excess_vw = rnorm(dplyr::n(), 0, 0.05)
+    ) |>
+    tibble::as_tibble()
+}
+
+test_that("compute_long_short_returns returns top - bottom by default", {
+  panel <- make_portfolio_panel()
+  out <- compute_long_short_returns(panel)
+  expect_named(out, c("date", "ret_excess_ew", "ret_excess_vw"))
+  expect_equal(nrow(out), 12L)
+
+  # Sanity-check one date
+  d <- panel$date[1]
+  rows <- panel[panel$date == d, ]
+  expected_ew <- rows$ret_excess_ew[rows$portfolio == max(rows$portfolio)] -
+    rows$ret_excess_ew[rows$portfolio == min(rows$portfolio)]
+  expect_equal(out$ret_excess_ew[out$date == d], expected_ew)
+})
+
+test_that("compute_long_short_returns returns NA when only one portfolio", {
+  # Mirrors the case where assign_portfolio collapses to a single bucket
+  # because the sorting variable is constant. The long-short is undefined
+  # (no investment), and the function should return NA rather than error
+  # with `object 'top' not found`.
+  panel <- make_portfolio_panel(n_portfolios = 1L)
+  out <- compute_long_short_returns(panel)
+  expect_named(out, c("date", "ret_excess_ew", "ret_excess_vw"))
+  expect_equal(nrow(out), 12L)
+  expect_true(all(is.na(out$ret_excess_ew)))
+  expect_true(all(is.na(out$ret_excess_vw)))
+})
+
+test_that("compute_long_short_returns handles a single per-date long leg", {
+  # All dates have a bottom portfolio; only some dates have a top portfolio.
+  panel <- make_portfolio_panel(n_portfolios = 2L, n_months = 4L)
+  panel <- panel[!(panel$date == panel$date[1] & panel$portfolio == 2L), ]
+  out <- compute_long_short_returns(panel)
+  expect_equal(nrow(out), 4L)
+  expect_true(is.na(out$ret_excess_ew[out$date == panel$date[1]]))
+  expect_true(all(!is.na(out$ret_excess_ew[out$date != panel$date[1]])))
+})


### PR DESCRIPTION
## Summary

- Fix `compute_long_short_returns()` crashing with `object 'top' not found` when the input panel contains only one distinct portfolio value (typically after `assign_portfolio()` collapses to a single bucket on a constant sorting variable and emits its existing warning).
- Encode the long/short label as a `factor` with fixed levels `c("bottom", "top")` and pass `names_expand = TRUE` to `pivot_wider()`, so both columns are guaranteed regardless of how many portfolios survive the filter. `top - bottom` then evaluates to `NA` on dates with no top (or no bottom) leg, consistent with "no investment, no return".
- Adds `tests/testthat/test-compute_long_short_returns.R` covering the normal case, the fully-degenerate single-portfolio panel, and the partial case where the top leg is missing on some dates.

## Test plan

- [x] `devtools::test(filter = "compute_long_short_returns")` — 10 PASS
- [x] `devtools::test(filter = "compute_portfolio_returns")` — 89 PASS
- [x] Full suite (`devtools::test()`) — 672 PASS, 0 FAIL, 0 WARN
- [x] roborev review (job 273) — Pass, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)