### PR TITLE
Add llms.txt support for LLM coding agents

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 .lintr
 ^data-raw$
 ^CLAUDE\.md$
+^llms\.txt$
+^llms-full\.txt$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.6.0.9002
+Version: 0.6.0.9003
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Improvements
 
+- Added `llms.txt` and `llms-full.txt` (following the llms.txt convention) to
+  expose the package API to LLM coding agents, generated from the package
+  documentation via `data-raw/generate_llms_txt.R`.
 - Removed the "experimental" lifecycle badge from `assign_portfolio()`,
   `compute_breakpoints()`, `compute_rolling_value()`, `estimate_model()`,
   and `join_lagged_values()`, which are now considered stable.

--- a/data-raw/generate_llms_txt.R
+++ b/data-raw/generate_llms_txt.R
@@ -1,0 +1,297 @@
+# Generate `llms.txt` and `llms-full.txt` from the package documentation.
+#
+# These files expose the tidyfinance API to LLM coding agents following the
+# llms.txt convention (https://llmstxt.org). They are plain text and live on
+# their own -- they do NOT require a pkgdown/Quarto site. The convention is to
+# serve them at a site root (e.g. https://www.tidy-finance.org/r/llms.txt), but
+# they work equally well from the repository root or shipped inside the package.
+#
+# `llms.txt`       -- a compact, grouped index of every exported function with a
+#                     one-line description and a link to its annotated source.
+# `llms-full.txt`  -- full inline reference (title, description, usage,
+#                     arguments, value, examples) for every exported function.
+#
+# Run from the package root with:  Rscript data-raw/generate_llms_txt.R
+# Re-run whenever the documentation in man/*.Rd changes.
+
+repo   <- "tidy-finance/r-tidyfinance"
+branch <- "main"
+
+# ---- small Rd parsing helpers (base R only) --------------------------------
+
+# Return the content of the first `\tag{...}` block, NULL if absent. Handles
+# nested braces.
+find_block <- function(txt, tag) {
+  m <- regexpr(paste0("\\\\", tag, "\\{"), txt)
+  if (m == -1L) return(NULL)
+  brace_after(txt, m + attr(m, "match.length") - 1L)$content
+}
+
+# Return the content of every `\tag{...}` block as a character vector.
+find_all <- function(txt, tag) {
+  out <- character(0)
+  pat <- paste0("\\\\", tag, "\\{")
+  pos <- 1L
+  repeat {
+    sub <- substring(txt, pos)
+    m <- regexpr(pat, sub)
+    if (m == -1L) break
+    open <- pos + m + attr(m, "match.length") - 2L
+    res <- brace_after(txt, open)
+    out <- c(out, res$content)
+    pos <- res$end
+  }
+  out
+}
+
+# Given the index of an opening `{`, return list(content, end) where `end` is
+# the index just after the matching `}`.
+brace_after <- function(txt, open_idx) {
+  n <- nchar(txt)
+  i <- open_idx + 1L
+  depth <- 1L
+  start <- i
+  while (i <= n && depth > 0L) {
+    c <- substr(txt, i, i)
+    if (c == "{") depth <- depth + 1L
+    else if (c == "}") {
+      depth <- depth - 1L
+      if (depth == 0L) break
+    }
+    i <- i + 1L
+  }
+  list(content = substr(txt, start, i - 1L), end = i + 1L)
+}
+
+# Resolve `\ifelse{html}{a}{b}` -> b, then `\href{url}{text}` -> text,
+# drop `\figure{...}`, unwrap single-argument formatting macros, and unescape
+# Rd specials. Leaves plain text suitable for Markdown.
+strip_inline <- function(s) {
+  if (is.null(s) || !nzchar(s)) return("")
+
+  repl_two <- function(t, tag, keep) {
+    pat <- paste0("\\\\", tag, "\\{")
+    repeat {
+      m <- regexpr(pat, t)
+      if (m == -1L) break
+      a <- brace_after(t, m + attr(m, "match.length") - 2L)
+      if (a$end - 1L <= nchar(t) && substr(t, a$end - 1L, a$end - 1L) == "{") {
+        b <- brace_after(t, a$end - 1L)
+        rep <- switch(keep, first = a$content, second = b$content, "")
+        t <- paste0(substr(t, 1L, m - 1L), rep, substring(t, b$end))
+      } else {
+        rep <- switch(keep, first = a$content, "")
+        t <- paste0(substr(t, 1L, m - 1L), rep, substring(t, a$end))
+      }
+    }
+    t
+  }
+  # `\ifelse{html}{html-branch}{text-branch}` -> text-branch
+  repeat {
+    m <- regexpr("\\\\ifelse\\{", s)
+    if (m == -1L) break
+    cond <- brace_after(s, m + attr(m, "match.length") - 2L)
+    yes  <- brace_after(s, cond$end - 1L)
+    no   <- brace_after(s, yes$end - 1L)
+    s <- paste0(substr(s, 1L, m - 1L), no$content, substring(s, no$end))
+  }
+  s <- repl_two(s, "href", "second")
+  s <- repl_two(s, "figure", "none")
+
+  single <- c("code", "link", "emph", "strong", "verb", "pkg", "dQuote",
+              "sQuote", "eqn", "samp", "file", "env", "option", "var",
+              "command", "url", "cite", "email", "acronym", "donttest",
+              "dontrun", "R")
+  for (tag in single) {
+    pat <- paste0("\\\\", tag, "\\{")
+    repeat {
+      m <- regexpr(pat, s)
+      if (m == -1L) break
+      inner <- brace_after(s, m + attr(m, "match.length") - 2L)
+      s <- paste0(substr(s, 1L, m - 1L), inner$content, substring(s, inner$end))
+    }
+  }
+  s <- gsub("\\\\link\\[[^]]*\\]", "", s)
+  s <- gsub("\\\\dots|\\\\ldots", "...", s)
+  s <- gsub("(?<!\\\\)%.*", "", s, perl = TRUE)       # Rd comments, not \%
+  s <- gsub("\\\\%", "%", s)
+  s <- gsub("\\\\\\{", "{", s); s <- gsub("\\\\\\}", "}", s)
+  s <- gsub("\\\\&", "&", s)
+  s <- gsub("[ \t]+", " ", s)
+  trimws(s)
+}
+
+# Parse `\item{name}{description}` pairs out of an \arguments block.
+parse_items <- function(block) {
+  items <- list()
+  pos <- 1L
+  repeat {
+    sub <- substring(block, pos)
+    m <- regexpr("\\\\item\\{", sub)
+    if (m == -1L) break
+    open <- pos + m + attr(m, "match.length") - 2L
+    nm <- brace_after(block, open)
+    j <- nm$end - 1L
+    while (j <= nchar(block) && substr(block, j, j) %in% c(" ", "\t", "\n")) j <- j + 1L
+    if (j <= nchar(block) && substr(block, j, j) == "{") {
+      ds <- brace_after(block, j)
+    } else {
+      ds <- list(content = "", end = nm$end)
+    }
+    items[[length(items) + 1L]] <- list(
+      name = strip_inline(nm$content), desc = strip_inline(ds$content)
+    )
+    pos <- ds$end
+  }
+  items
+}
+
+strip_comments_code <- function(s) {
+  s <- gsub("(?<!\\\\)%.*", "", s, perl = TRUE)
+  gsub("\\\\%", "%", s)
+}
+
+# ---- read package metadata --------------------------------------------------
+
+d <- read.dcf("DESCRIPTION")
+pkg     <- d[1, "Package"]
+title   <- gsub("\\s+", " ", d[1, "Title"])
+pkgdesc <- gsub("\\s+", " ", d[1, "Description"])
+
+# ---- parse all man/*.Rd -----------------------------------------------------
+
+rd_files <- sort(list.files("man", pattern = "\\.Rd$", full.names = TRUE))
+funcs <- lapply(rd_files, function(f) {
+  txt <- paste(readLines(f, warn = FALSE), collapse = "\n")
+  name <- find_block(txt, "name")
+  if (is.null(name)) return(NULL)
+  src <- regmatches(txt, regexpr("edit documentation in (\\S+)", txt))
+  src <- if (length(src)) sub("edit documentation in ", "", src) else NA_character_
+  concept <- find_all(txt, "concept")
+  list(
+    name     = trimws(name),
+    src      = src,
+    concept  = if (length(concept)) concept[1] else NA_character_,
+    title    = strip_inline(find_block(txt, "title")),
+    desc     = find_block(txt, "description"),
+    usage    = find_block(txt, "usage"),
+    args     = find_block(txt, "arguments"),
+    value    = find_block(txt, "value"),
+    examples = find_block(txt, "examples")
+  )
+})
+funcs <- Filter(Negate(is.null), funcs)
+funcs <- Filter(function(x) x$name != paste0(pkg, "-package"), funcs)
+
+# ---- section ordering / titles ---------------------------------------------
+
+section_titles <- c(
+  "download functions"            = "Download functions",
+  "WRDS functions"                = "WRDS functions",
+  "pseudo functions"              = "Pseudo-data functions (no credentials required)",
+  "estimation functions"          = "Estimation functions",
+  "portfolio functions"           = "Portfolio sorting functions",
+  "rolling and lagging functions" = "Rolling and lagging functions",
+  "utility functions"             = "Utility and helper functions"
+)
+
+url_for <- function(fn) {
+  if (!is.na(fn$src)) paste0("https://github.com/", repo, "/blob/", branch, "/", fn$src)
+  else paste0("https://github.com/", repo)
+}
+
+by_name <- function(fns) fns[order(vapply(fns, function(x) x$name, ""))]
+
+groups <- setNames(vector("list", length(section_titles)), names(section_titles))
+other <- list()
+for (fn in funcs) {
+  c <- fn$concept
+  if (!is.na(c) && c %in% names(groups)) groups[[c]] <- c(groups[[c]], list(fn))
+  else other <- c(other, list(fn))
+}
+
+# ---- write llms.txt ---------------------------------------------------------
+
+out <- c(
+  paste0("# ", pkg), "",
+  paste0("> ", title, ". ", pkgdesc), "",
+  paste0(pkg, " is an R package of helper functions for empirical research in ",
+         "financial economics, accompanying the book Tidy Finance with R ",
+         "(Scheuch, Voigt, and Weiss, 2023). Each link points to the function's ",
+         "annotated source on GitHub. For complete inline reference (signatures, ",
+         "arguments, return values, and runnable examples) see llms-full.txt in ",
+         "the same location."), ""
+)
+for (key in names(section_titles)) {
+  fns <- groups[[key]]
+  if (length(fns) == 0) next
+  out <- c(out, paste0("## ", section_titles[[key]]), "")
+  for (fn in by_name(fns)) {
+    out <- c(out, paste0("- [", fn$name, "](", url_for(fn), "): ", fn$title))
+  }
+  out <- c(out, "")
+}
+if (length(other)) {
+  out <- c(out, "## Other", "")
+  for (fn in by_name(other)) {
+    out <- c(out, paste0("- [", fn$name, "](", url_for(fn), "): ", fn$title))
+  }
+  out <- c(out, "")
+}
+out <- c(out,
+  "## Optional", "",
+  paste0("- [Package overview](https://github.com/", repo,
+         "): README, installation, and contribution guide"),
+  "- [Tidy Finance with R (book)](https://www.tidy-finance.org/r/): full methodology and chapter-by-chapter explanations",
+  "- [llms-full.txt](llms-full.txt): full inline documentation for every exported function"
+)
+writeLines(out, "llms.txt")
+
+# ---- write llms-full.txt ----------------------------------------------------
+
+full <- c(
+  paste0("# ", pkg, " — full function reference"), "",
+  paste0("> ", title, ". ", pkgdesc), "",
+  "Generated from the package documentation (man/*.Rd). One section per exported function.", ""
+)
+ordered <- unlist(lapply(names(section_titles), function(k) by_name(groups[[k]])), recursive = FALSE)
+ordered <- c(ordered, by_name(other))
+for (fn in ordered) {
+  full <- c(full, paste0("## ", fn$name), "", fn$title, "")
+  dd <- strip_inline(fn$desc)
+  if (nzchar(dd)) full <- c(full, dd, "")
+  if (!is.null(fn$usage)) {
+    u <- trimws(strip_comments_code(fn$usage))
+    full <- c(full, "Usage:", "```r", u, "```", "")
+  }
+  if (!is.null(fn$args)) {
+    items <- parse_items(fn$args)
+    if (length(items)) {
+      full <- c(full, "Arguments:")
+      for (it in items) full <- c(full, paste0("- `", it$name, "`: ", it$desc))
+      full <- c(full, "")
+    }
+  }
+  if (!is.null(fn$value)) {
+    v <- strip_inline(fn$value)
+    if (nzchar(v)) full <- c(full, paste0("Value: ", v), "")
+  }
+  if (!is.null(fn$examples)) {
+    ex <- strip_comments_code(fn$examples)
+    for (tag in c("donttest", "dontrun")) {
+      pat <- paste0("\\\\", tag, "\\{")
+      repeat {
+        m <- regexpr(pat, ex)
+        if (m == -1L) break
+        inner <- brace_after(ex, m + attr(m, "match.length") - 2L)
+        ex <- paste0(substr(ex, 1L, m - 1L), inner$content, substring(ex, inner$end))
+      }
+    }
+    ex <- trimws(ex)
+    if (nzchar(ex)) full <- c(full, "Examples:", "```r", ex, "```", "")
+  }
+  full <- c(full, paste0("Source: ", url_for(fn)), "")
+}
+writeLines(full, "llms-full.txt")
+
+message("Wrote llms.txt and llms-full.txt for ", length(ordered), " functions.")

--- a/data-raw/generate_llms_txt.R
+++ b/data-raw/generate_llms_txt.R
@@ -4,7 +4,7 @@
 # llms.txt convention (https://llmstxt.org). They are plain text and live on
 # their own -- they do NOT require a pkgdown/Quarto site. The convention is to
 # serve them at a site root (e.g. https://www.tidy-finance.org/r/llms.txt), but
-# they work equally well from the repository root or shipped inside the package.
+# they work equally well from the repository root or shipped in the package.
 #
 # `llms.txt`       -- a compact, grouped index of every exported function with a
 #                     one-line description and a link to its annotated source.
@@ -14,10 +14,30 @@
 # Run from the package root with:  Rscript data-raw/generate_llms_txt.R
 # Re-run whenever the documentation in man/*.Rd changes.
 
-repo   <- "tidy-finance/r-tidyfinance"
+repo <- "tidy-finance/r-tidyfinance"
 branch <- "main"
 
 # ---- small Rd parsing helpers (base R only) --------------------------------
+
+# Given the index of an opening `{`, return list(content, end) where `end` is
+# the index just after the matching `}`.
+brace_after <- function(txt, open_idx) {
+  n <- nchar(txt)
+  i <- open_idx + 1L
+  depth <- 1L
+  start <- i
+  while (i <= n && depth > 0L) {
+    ch <- substr(txt, i, i)
+    if (ch == "{") {
+      depth <- depth + 1L
+    } else if (ch == "}") {
+      depth <- depth - 1L
+      if (depth == 0L) break
+    }
+    i <- i + 1L
+  }
+  list(content = substr(txt, start, i - 1L), end = i + 1L)
+}
 
 # Return the content of the first `\tag{...}` block, NULL if absent. Handles
 # nested braces.
@@ -44,25 +64,6 @@ find_all <- function(txt, tag) {
   out
 }
 
-# Given the index of an opening `{`, return list(content, end) where `end` is
-# the index just after the matching `}`.
-brace_after <- function(txt, open_idx) {
-  n <- nchar(txt)
-  i <- open_idx + 1L
-  depth <- 1L
-  start <- i
-  while (i <= n && depth > 0L) {
-    c <- substr(txt, i, i)
-    if (c == "{") depth <- depth + 1L
-    else if (c == "}") {
-      depth <- depth - 1L
-      if (depth == 0L) break
-    }
-    i <- i + 1L
-  }
-  list(content = substr(txt, start, i - 1L), end = i + 1L)
-}
-
 # Resolve `\ifelse{html}{a}{b}` -> b, then `\href{url}{text}` -> text,
 # drop `\figure{...}`, unwrap single-argument formatting macros, and unescape
 # Rd specials. Leaves plain text suitable for Markdown.
@@ -75,7 +76,9 @@ strip_inline <- function(s) {
       m <- regexpr(pat, t)
       if (m == -1L) break
       a <- brace_after(t, m + attr(m, "match.length") - 2L)
-      if (a$end - 1L <= nchar(t) && substr(t, a$end - 1L, a$end - 1L) == "{") {
+      has_second <- a$end - 1L <= nchar(t) &&
+        substr(t, a$end - 1L, a$end - 1L) == "{"
+      if (has_second) {
         b <- brace_after(t, a$end - 1L)
         rep <- switch(keep, first = a$content, second = b$content, "")
         t <- paste0(substr(t, 1L, m - 1L), rep, substring(t, b$end))
@@ -91,8 +94,8 @@ strip_inline <- function(s) {
     m <- regexpr("\\\\ifelse\\{", s)
     if (m == -1L) break
     cond <- brace_after(s, m + attr(m, "match.length") - 2L)
-    yes  <- brace_after(s, cond$end - 1L)
-    no   <- brace_after(s, yes$end - 1L)
+    yes <- brace_after(s, cond$end - 1L)
+    no <- brace_after(s, yes$end - 1L)
     s <- paste0(substr(s, 1L, m - 1L), no$content, substring(s, no$end))
   }
   s <- repl_two(s, "href", "second")
@@ -115,7 +118,8 @@ strip_inline <- function(s) {
   s <- gsub("\\\\dots|\\\\ldots", "...", s)
   s <- gsub("(?<!\\\\)%.*", "", s, perl = TRUE)       # Rd comments, not \%
   s <- gsub("\\\\%", "%", s)
-  s <- gsub("\\\\\\{", "{", s); s <- gsub("\\\\\\}", "}", s)
+  s <- gsub("\\\\\\{", "{", s)
+  s <- gsub("\\\\\\}", "}", s)
   s <- gsub("\\\\&", "&", s)
   s <- gsub("[ \t]+", " ", s)
   trimws(s)
@@ -132,7 +136,10 @@ parse_items <- function(block) {
     open <- pos + m + attr(m, "match.length") - 2L
     nm <- brace_after(block, open)
     j <- nm$end - 1L
-    while (j <= nchar(block) && substr(block, j, j) %in% c(" ", "\t", "\n")) j <- j + 1L
+    while (j <= nchar(block) &&
+           substr(block, j, j) %in% c(" ", "\t", "\n")) {
+      j <- j + 1L
+    }
     if (j <= nchar(block) && substr(block, j, j) == "{") {
       ds <- brace_after(block, j)
     } else {
@@ -146,6 +153,7 @@ parse_items <- function(block) {
   items
 }
 
+# Strip Rd comments from a verbatim block (usage/examples), keeping `\%`.
 strip_comments_code <- function(s) {
   s <- gsub("(?<!\\\\)%.*", "", s, perl = TRUE)
   gsub("\\\\%", "%", s)
@@ -154,8 +162,8 @@ strip_comments_code <- function(s) {
 # ---- read package metadata --------------------------------------------------
 
 d <- read.dcf("DESCRIPTION")
-pkg     <- d[1, "Package"]
-title   <- gsub("\\s+", " ", d[1, "Title"])
+pkg <- d[1, "Package"]
+title <- gsub("\\s+", " ", d[1, "Title"])
 pkgdesc <- gsub("\\s+", " ", d[1, "Description"])
 
 # ---- parse all man/*.Rd -----------------------------------------------------
@@ -166,17 +174,21 @@ funcs <- lapply(rd_files, function(f) {
   name <- find_block(txt, "name")
   if (is.null(name)) return(NULL)
   src <- regmatches(txt, regexpr("edit documentation in (\\S+)", txt))
-  src <- if (length(src)) sub("edit documentation in ", "", src) else NA_character_
+  src <- if (length(src)) {
+    sub("edit documentation in ", "", src)
+  } else {
+    NA_character_
+  }
   concept <- find_all(txt, "concept")
   list(
-    name     = trimws(name),
-    src      = src,
-    concept  = if (length(concept)) concept[1] else NA_character_,
-    title    = strip_inline(find_block(txt, "title")),
-    desc     = find_block(txt, "description"),
-    usage    = find_block(txt, "usage"),
-    args     = find_block(txt, "arguments"),
-    value    = find_block(txt, "value"),
+    name = trimws(name),
+    src = src,
+    concept = if (length(concept)) concept[1] else NA_character_,
+    title = strip_inline(find_block(txt, "title")),
+    desc = find_block(txt, "description"),
+    usage = find_block(txt, "usage"),
+    args = find_block(txt, "arguments"),
+    value = find_block(txt, "value"),
     examples = find_block(txt, "examples")
   )
 })
@@ -186,41 +198,51 @@ funcs <- Filter(function(x) x$name != paste0(pkg, "-package"), funcs)
 # ---- section ordering / titles ---------------------------------------------
 
 section_titles <- c(
-  "download functions"            = "Download functions",
-  "WRDS functions"                = "WRDS functions",
-  "pseudo functions"              = "Pseudo-data functions (no credentials required)",
-  "estimation functions"          = "Estimation functions",
-  "portfolio functions"           = "Portfolio sorting functions",
+  "download functions" = "Download functions",
+  "WRDS functions" = "WRDS functions",
+  "pseudo functions" = "Pseudo-data functions (no credentials required)",
+  "estimation functions" = "Estimation functions",
+  "portfolio functions" = "Portfolio sorting functions",
   "rolling and lagging functions" = "Rolling and lagging functions",
-  "utility functions"             = "Utility and helper functions"
+  "utility functions" = "Utility and helper functions"
 )
 
 url_for <- function(fn) {
-  if (!is.na(fn$src)) paste0("https://github.com/", repo, "/blob/", branch, "/", fn$src)
-  else paste0("https://github.com/", repo)
+  if (is.na(fn$src)) {
+    return(paste0("https://github.com/", repo))
+  }
+  paste0("https://github.com/", repo, "/blob/", branch, "/", fn$src)
 }
 
 by_name <- function(fns) fns[order(vapply(fns, function(x) x$name, ""))]
 
-groups <- setNames(vector("list", length(section_titles)), names(section_titles))
+groups <- setNames(
+  vector("list", length(section_titles)), names(section_titles)
+)
 other <- list()
 for (fn in funcs) {
-  c <- fn$concept
-  if (!is.na(c) && c %in% names(groups)) groups[[c]] <- c(groups[[c]], list(fn))
-  else other <- c(other, list(fn))
+  con <- fn$concept
+  if (!is.na(con) && con %in% names(groups)) {
+    groups[[con]] <- c(groups[[con]], list(fn))
+  } else {
+    other <- c(other, list(fn))
+  }
 }
 
 # ---- write llms.txt ---------------------------------------------------------
 
+intro <- paste0(
+  pkg, " is an R package of helper functions for empirical research in ",
+  "financial economics, accompanying the book Tidy Finance with R ",
+  "(Scheuch, Voigt, and Weiss, 2023). Each link points to the function's ",
+  "annotated source on GitHub. For complete inline reference (signatures, ",
+  "arguments, return values, and runnable examples) see llms-full.txt in ",
+  "the same location."
+)
 out <- c(
   paste0("# ", pkg), "",
   paste0("> ", title, ". ", pkgdesc), "",
-  paste0(pkg, " is an R package of helper functions for empirical research in ",
-         "financial economics, accompanying the book Tidy Finance with R ",
-         "(Scheuch, Voigt, and Weiss, 2023). Each link points to the function's ",
-         "annotated source on GitHub. For complete inline reference (signatures, ",
-         "arguments, return values, and runnable examples) see llms-full.txt in ",
-         "the same location."), ""
+  intro, ""
 )
 for (key in names(section_titles)) {
   fns <- groups[[key]]
@@ -238,12 +260,21 @@ if (length(other)) {
   }
   out <- c(out, "")
 }
-out <- c(out,
+out <- c(
+  out,
   "## Optional", "",
-  paste0("- [Package overview](https://github.com/", repo,
-         "): README, installation, and contribution guide"),
-  "- [Tidy Finance with R (book)](https://www.tidy-finance.org/r/): full methodology and chapter-by-chapter explanations",
-  "- [llms-full.txt](llms-full.txt): full inline documentation for every exported function"
+  paste0(
+    "- [Package overview](https://github.com/", repo,
+    "): README, installation, and contribution guide"
+  ),
+  paste0(
+    "- [Tidy Finance with R (book)](https://www.tidy-finance.org/r/): ",
+    "full methodology and chapter-by-chapter explanations"
+  ),
+  paste0(
+    "- [llms-full.txt](llms-full.txt): full inline documentation for ",
+    "every exported function"
+  )
 )
 writeLines(out, "llms.txt")
 
@@ -252,9 +283,15 @@ writeLines(out, "llms.txt")
 full <- c(
   paste0("# ", pkg, " — full function reference"), "",
   paste0("> ", title, ". ", pkgdesc), "",
-  "Generated from the package documentation (man/*.Rd). One section per exported function.", ""
+  paste0(
+    "Generated from the package documentation (man/*.Rd). One section per ",
+    "exported function."
+  ), ""
 )
-ordered <- unlist(lapply(names(section_titles), function(k) by_name(groups[[k]])), recursive = FALSE)
+ordered <- unlist(
+  lapply(names(section_titles), function(k) by_name(groups[[k]])),
+  recursive = FALSE
+)
 ordered <- c(ordered, by_name(other))
 for (fn in ordered) {
   full <- c(full, paste0("## ", fn$name), "", fn$title, "")
@@ -284,7 +321,9 @@ for (fn in ordered) {
         m <- regexpr(pat, ex)
         if (m == -1L) break
         inner <- brace_after(ex, m + attr(m, "match.length") - 2L)
-        ex <- paste0(substr(ex, 1L, m - 1L), inner$content, substring(ex, inner$end))
+        ex <- paste0(
+          substr(ex, 1L, m - 1L), inner$content, substring(ex, inner$end)
+        )
       }
     }
     ex <- trimws(ex)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,2959 @@
+# tidyfinance — full function reference
+
+> Tidy Finance Helper Functions. Helper functions for empirical research in financial economics, addressing a variety of topics covered in Scheuch, Voigt, and Weiss (2023) <doi:10.1201/b23237>. The package is designed to provide shortcuts for issues extensively discussed in the book, facilitating easier application of its concepts. For more information and resources related to the book, visit <https://www.tidy-finance.org/r/index.html>.
+
+Generated from the package documentation (man/*.Rd). One section per exported function.
+
+## download_data
+
+Download and Process Data Based on Domain and Dataset
+
+Downloads and processes data based on the specified domain (e.g.,
+Fama-French factors, Global Q factors, or macro predictors), dataset,
+and date range. This function checks if the specified domain is supported
+and then delegates to the appropriate function for downloading and
+processing the data.
+
+Usage:
+```r
+download_data(
+  domain = NULL,
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  ...
+)
+```
+
+Arguments:
+- `domain`: The domain of the dataset to download (e.g.,
+"famafrench", "globalq", "macro_predictors", "wrds", "pseudo",
+"constituents", "fred", "stock_prices", "osap", "tidyfinance").
+Use "pseudo" to obtain pseudo data with the same schema as
+"wrds" for testing or rendering without a WRDS subscription.
+- `dataset`: Optional. The specific dataset to download within the
+domain.
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, the full dataset or a subset is returned, depending on the
+dataset type.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, the full dataset or a subset is returned, depending on the
+dataset type.
+- `type`: [Deprecated] Use domain and
+dataset instead.
+- `...`: Additional arguments passed to specific download functions
+depending on the domain. For instance, if domain is
+"constituents", arguments are passed to
+download_data_constituents(). If domain is "tidyfinance" and
+dataset is "factor_library", arguments are either filter inputs
+(e.g., sorting_variable, rebalancing, fill_all) or an explicit
+ids vector that bypasses the grid filter and downloads the
+specified portfolios directly via download_factor_library_ids();
+see download_data_huggingface() for details.
+
+Value: A tibble with processed data, including dates and the relevant
+financial metrics, filtered by the specified date range.
+
+Examples:
+```r
+download_data(
+  "famafrench",
+  "Fama/French 5 Factors (2x3) [Daily]",
+  "2000-01-01",
+  "2020-12-31"
+)
+download_data("macro_predictors", "monthly", "2000-01-01", "2020-12-31")
+download_data("constituents", index = "DAX")
+download_data("fred", series = c("GDP", "CPIAUCNS"))
+download_data("stock_prices", symbols = c("AAPL", "MSFT"))
+download_data(
+  "tidyfinance",
+  "risk_free",
+  "2020-01-01",
+  "2020-12-31"
+)
+download_data(
+  "tidyfinance",
+  "high_frequency_sp500",
+  "2007-07-26",
+  "2007-07-27"
+)
+download_data(
+  "tidyfinance",
+  "factor_library",
+  sorting_variable = "52w",
+  rebalancing = "annual"
+)
+download_data("tidyfinance", "factor_library", ids = c(1L, 2L, 3L))
+download_data("tidyfinance", "factor_library_grid")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data.R
+
+## download_data_constituents
+
+Download Constituent Data
+
+Downloads and processes the constituent data for a specified financial
+index. The data is fetched from a remote CSV file, filtered, and cleaned to
+provide relevant information about constituents.
+
+Usage:
+```r
+download_data_constituents(index)
+```
+
+Arguments:
+- `index`: A character string specifying the name of the financial index
+for which to download constituent data. The index must be one of the
+supported indexes listed by {list_supported_indexes()}.
+
+Value: A tibble with five columns:
+\describe{
+\item{symbol}{The ticker symbol of the equity constituent.}
+\item{name}{The name of the equity constituent.}
+\item{location}{The location where the company is based.}
+\item{exchange}{The exchange where the equity is traded.}
+\item{currency}{The currency in which the equity is traded, derived
+from the exchange.}
+}
+The tibble is filtered to exclude non-equity entries, blacklisted symbols,
+empty names, and any entries containing the index name or "CASH".
+
+Examples:
+```r
+download_data_constituents("DAX")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_constituents.R
+
+## download_data_factors_ff
+
+Download and Process Fama-French Factor Data
+
+Downloads and processes Fama-French factor data based on the specified
+dataset name and date range. The data is downloaded directly from Kenneth
+French's data library and processed into a structured format, including
+date conversion, scaling factor values, and filtering by the specified date
+range.
+
+Usage:
+```r
+download_data_factors_ff(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated()
+)
+```
+
+Arguments:
+- `dataset`: The name of the Fama-French dataset to download (e.g.,
+"Fama/French 3 Factors").
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, the full dataset is returned.
+- `end_date`: Optional. A character string or Date object in "YYYY-MM-DD"
+format specifying the end date for the data. If not provided, the full
+dataset is returned.
+- `type`: [Deprecated] Use dataset instead.
+
+Value: A tibble with processed factor data, including the date, risk-free
+rate, market excess return, and other factors, filtered by the specified
+date range.
+
+Examples:
+```r
+download_data_factors_ff(
+    "Fama/French 3 Factors", "2000-01-01", "2020-12-31"
+  )
+  download_data_factors_ff(
+    "10 Industry Portfolios", "2000-01-01", "2020-12-31"
+  )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_factors.R
+
+## download_data_factors_q
+
+Download and Process Global Q Factor Data
+
+Downloads and processes Global Q factor data based on the
+specified dataset, date range, and source URL. The processing
+includes date conversion, renaming variables to a standardized
+format, scaling factor values, and filtering by the specified
+date range.
+
+Usage:
+```r
+download_data_factors_q(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  url = "https://global-q.org/uploads/1/2/2/6/122679606/"
+)
+```
+
+Arguments:
+- `dataset`: The name of the dataset to download (e.g.,
+"q5_factors_daily_2023.csv", "q5_factors_monthly_2023.csv").
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If
+not provided, the full dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, the full dataset is returned.
+- `type`: [Deprecated] Use dataset
+instead.
+- `url`: The base URL from which to download the dataset files.
+
+Value: A tibble with processed factor data, including the date,
+risk-free rate, market excess return, and other factors,
+filtered by the specified date range.
+
+Examples:
+```r
+download_data_factors_q("q5_factors_daily_2024", "2020-01-01", "2020-12-31")
+download_data_factors_q("q5_factors_annual_2024")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_factors.R
+
+## download_data_fred
+
+Download and Process Data from FRED
+
+Downloads a specified data series from the Federal Reserve Economic Data
+(FRED) website, processes the data, and returns it as a tibble.
+
+Usage:
+```r
+download_data_fred(series, start_date = NULL, end_date = NULL)
+```
+
+Arguments:
+- `series`: A character vector specifying the FRED series ID(s) to
+download.
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, the full dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, the full dataset is returned.
+
+Value: A tibble containing the processed data with three columns:
+\describe{
+\item{date}{The date corresponding to the data point.}
+\item{value}{The value of the data series at that date.}
+\item{series}{The FRED series ID corresponding to the data.}
+}
+
+Examples:
+```r
+download_data_fred("CPIAUCNS")
+  download_data_fred(c("GDP", "CPIAUCNS"), "2010-01-01", "2010-12-31")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_fred.R
+
+## download_data_huggingface
+
+Download data from a Hugging Face dataset
+
+Downloads data from a supported Hugging Face dataset. For
+"high_frequency_sp500", parquet files are filtered by date range and
+row-bound. For "factor_library", portfolio characteristics are selected via
+filter_factor_library_grid(), the matching return data is downloaded, and
+the result is filtered to start_date/end_date when both are supplied.
+For "factor_library_grid", the grid itself is returned via
+{download_factor_library_grid()}.
+
+Usage:
+```r
+download_data_huggingface(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  ...
+)
+```
+
+Arguments:
+- `dataset`: Character(1). The dataset to download. Supported values are
+"high_frequency_sp500", "factor_library", and "factor_library_grid".
+- `start_date`: Date or character. Start date (inclusive) in
+"YYYY-MM-DD" format. Used for "high_frequency_sp500" and
+"factor_library". When omitted for "factor_library", the full return
+history is returned; "high_frequency_sp500" falls back to a built-in
+sample window.
+- `end_date`: Date or character. End date (inclusive) in "YYYY-MM-DD"
+format. See start_date.
+- `type`: [Deprecated] Use dataset instead.
+- `...`: For dataset = "factor_library": either named arguments used
+to filter the portfolio grid, or ids = <vector> to bypass the grid
+filter and download specific portfolios directly via
+{download_factor_library_ids()}. Filter arguments take the form
+column = value, where value may be a vector to match multiple
+levels. Optionally pass fill_all = TRUE to leave unspecified columns
+unrestricted (default: FALSE, i.e. unspecified columns are fixed at
+the defaults listed below). Passing NULL for any parameter removes
+that filter entirely, returning all values for that column (e.g.,
+min_size_quantile = NULL includes all size groups). Passing an
+unrecognised column name raises an error listing the supported names.
+ids cannot be combined with filter arguments. Ignored when
+dataset != "factor_library". See the Details section for supported
+columns and their defaults.
+
+Value: A tibble with the downloaded data. For "high_frequency_sp500",
+contains 5-second aggregated orderbook snapshots filtered to the requested
+date range. For "factor_library", contains portfolio return data joined
+with the full grid metadata for the matched portfolio IDs.
+
+Examples:
+```r
+download_data_huggingface(
+    "high_frequency_sp500", "2007-07-26", "2007-07-27"
+  )
+  download_data_huggingface(
+    "factor_library",
+    sorting_variable = "52w",
+    rebalancing = "annual"
+  )
+  download_data_huggingface(
+    "factor_library", sorting_variable = "ag", fill_all = TRUE
+  )
+  download_data_huggingface(
+    "factor_library",
+    sorting_variable = "me",
+    start_date = "2000-01-01",
+    end_date = "2020-12-31"
+  )
+  download_data_huggingface("factor_library", ids = c(1L, 2L, 3L))
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R
+
+## download_data_macro_predictors
+
+Download and Process Macro Predictor Data
+
+Downloads and processes macroeconomic predictor data based on the
+specified dataset (monthly, quarterly, or annual), date range, and
+source URL. The function downloads the data from a Google Sheets
+export link. It processes the raw data into a structured format,
+calculating additional financial metrics and filtering by the
+specified date range.
+
+Usage:
+```r
+download_data_macro_predictors(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  sheet_id = "1bM7vCWd3WOt95Sf9qjLPZjoiafgF_8EG"
+)
+```
+
+Arguments:
+- `dataset`: The dataset to download ("monthly", "quarterly",
+"annual").
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If
+not provided, the full dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, the full dataset is returned.
+- `type`: [Deprecated] Use dataset
+instead.
+- `sheet_id`: The Google Sheets ID from which to download the
+dataset, with the default "1bM7vCWd3WOt95Sf9qjLPZjoiafgF_8EG".
+
+Value: A tibble with processed data, filtered by the specified
+date range and including financial metrics.
+
+Examples:
+```r
+download_data_macro_predictors("monthly")
+  download_data_macro_predictors("quarterly", "2000-01-01", "2020-12-31")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_macro_predictors.R
+
+## download_data_osap
+
+Download and Process Open Source Asset Pricing Data
+
+Downloads the data from
+Open Source Asset Pricing
+from Google Sheets using a specified sheet ID, processes the data
+by converting column names to snake_case, and optionally filters
+the data based on a provided date range.
+
+Usage:
+```r
+download_data_osap(
+  start_date = NULL,
+  end_date = NULL,
+  sheet_id = "1JyhcF5PRKHcputlioxlu5j5GyLo4JYyY"
+)
+```
+
+Arguments:
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If
+not provided, the full dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, the full dataset is returned.
+- `sheet_id`: A character string representing the Google Sheet ID
+from which to download the data. Default is
+"1JyhcF5PRKHcputlioxlu5j5GyLo4JYyY".
+
+Value: A tibble containing the processed data. The column names
+are converted to snake_case, and the data is filtered by the
+specified date range if start_date and end_date are provided.
+
+Examples:
+```r
+osap <- download_data_osap(
+    start_date = "2020-01-01", end_date = "2020-06-30"
+  )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_osap.R
+
+## download_data_risk_free
+
+Download Risk-Free Rate Data
+
+Downloads pre-processed risk-free rate data from the
+tidy-finance/risk-free dataset on HuggingFace. The dataset is
+updated monthly via a scheduled GitHub Actions workflow that splices the
+3-Month Treasury Bill Secondary Market Rate (pre-2001) with the 4-Week
+Treasury Bill Secondary Market Rate (from 2001 onwards) sourced from FRED.
+For monthly data, the monthly TB3MS series is spliced with the daily DTB4WK
+series aggregated to month-end. For daily data, the daily DTB3 series is
+spliced with the daily DTB4WK series, both at the business-day frequency
+provided by FRED.
+
+Usage:
+```r
+download_data_risk_free(
+  start_date = NULL,
+  end_date = NULL,
+  frequency = "monthly"
+)
+```
+
+Arguments:
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If
+not provided, the full dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, the full dataset is returned.
+- `frequency`: A character string, either "monthly" (default)
+or "daily", specifying the frequency of the returned data. Daily
+data starts in 1954-01-04 because of availability of DTB3, while
+monthly data starts in 1934-01-01.
+
+Value: A tibble with two columns:
+\describe{
+\item{date}{The date of the observation.}
+\item{risk_free}{The risk-free rate for the period.}
+}
+
+Examples:
+```r
+download_data_risk_free("2020-01-01", "2020-12-31")
+  download_data_risk_free(
+    "2020-01-01", "2020-12-31", frequency = "daily"
+  )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_risk_free.R
+
+## download_data_stock_prices
+
+Download Stock Data
+
+Downloads historical stock data from Yahoo Finance for given symbols and date
+range.
+
+Usage:
+```r
+download_data_stock_prices(symbols, start_date = NULL, end_date = NULL)
+```
+
+Arguments:
+- `symbols`: A character vector of stock symbols to download data for. At
+least one symbol must be provided.
+- `start_date`: Optional. A character string or Date object in "YYYY-MM-DD"
+format specifying the start date for the data. If not provided, a one-year
+subset of the dataset is returned (see {validate_dates()}).
+- `end_date`: Optional. A character string or Date object in "YYYY-MM-DD"
+format specifying the end date for the data. If not provided, a one-year
+subset of the dataset is returned (see {validate_dates()}).
+
+Value: A tibble containing the downloaded stock data with columns: symbol,
+date, volume, open, low, high, close, and adjusted_close.
+
+Examples:
+```r
+download_data_stock_prices(c("AAPL", "MSFT"))
+  download_data_stock_prices("GOOGL", "2021-01-01", "2022-01-01" )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_stock_prices.R
+
+## download_factor_library_grid
+
+Download the Factor Library Grid from Hugging Face
+
+Returns the tidy-finance/factor-library-grid dataset, which describes
+every portfolio construction available in the factor library (one row per
+construction, identified by id). Use the returned tibble to discover
+which (sorting_variable, weighting_scheme, rebalancing, ...) combinations
+exist before requesting their returns with
+{download_factor_library_ids()}.
+
+Usage:
+```r
+download_factor_library_grid()
+```
+
+Value: A tibble with one row per portfolio construction in the factor
+library, including the integer id column used by
+{download_factor_library_ids()}.
+
+Examples:
+```r
+download_factor_library_grid()
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R
+
+## download_factor_library_ids
+
+Download factor library returns for a vector of portfolio IDs
+
+Given a vector of portfolio IDs from the tidy-finance/factor-library-grid
+Hugging Face dataset, downloads the corresponding return data from the
+tidy-finance/factor-library dataset on Hugging Face. The function
+identifies the unique (sorting_variable, sorting_variable_lag, sorting_method, n_portfolios_main) combinations for the requested IDs,
+downloads one parquet file per combination in full, and then inner-joins
+to retain only the requested IDs. The grid metadata is joined back onto
+the result.
+
+Usage:
+```r
+download_factor_library_ids(ids)
+```
+
+Arguments:
+- `ids`: Integer or numeric vector of portfolio IDs to download. IDs
+correspond to rows of the tidy-finance/factor-library-grid dataset.
+
+Value: A tibble of portfolio returns with the grid metadata columns for
+the requested IDs appended.
+
+Examples:
+```r
+download_factor_library_ids(c(1L, 2L, 3L))
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R
+
+## disconnect_connection
+
+Disconnect Database Connection
+
+Safely disconnects an established database connection using the DBI package.
+
+Usage:
+```r
+disconnect_connection(con)
+```
+
+Arguments:
+- `con`: A database connection object created by DBI::dbConnect or any
+similar function that establishes a connection to a database.
+
+Value: TRUE, invisibly. Throws an error if the disconnection fails.
+
+Examples:
+```r
+con <- get_wrds_connection()
+disconnect_connection(con)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/disconnect_connection.R
+
+## download_data_wrds
+
+Download Data from WRDS
+
+Acts as a wrapper to download data from various WRDS datasets including
+CRSP, Compustat, and CCM links based on the specified dataset. It is
+designed to handle different datasets by redirecting to the appropriate
+specific data download function.
+
+Usage:
+```r
+download_data_wrds(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  ...
+)
+```
+
+Arguments:
+- `dataset`: A string specifying the dataset to download. Supported
+values: "crsp_monthly", "crsp_daily" for CRSP data,
+"compustat_annual", "compustat_quarterly" for Compustat data,
+"ccm_links" for CCM links data, "fisd" for FISD data, or
+"trace_enhanced" for TRACE data.
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, a subset of the dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, a subset of the dataset is returned.
+- `type`: [Deprecated] Use dataset instead.
+- `...`: Additional arguments passed to specific download functions
+depending on the dataset.
+
+Value: A data frame containing the requested data, with the structure
+and contents depending on the specified dataset.
+
+Examples:
+```r
+crsp_monthly <- download_data_wrds(
+    "crsp_monthly", "2020-01-01", "2020-12-31"
+  )
+  compustat_annual <- download_data_wrds(
+    "compustat_annual", "2020-01-01", "2020-12-31"
+  )
+  ccm_links <- download_data_wrds("ccm_links")
+  fisd <- download_data_wrds("fisd")
+  trace_enhanced <- download_data_wrds(
+    "trace_enhanced", cusips = "00101JAH9"
+  )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds.R
+
+## download_data_wrds_ccm_links
+
+Download CCM Links from WRDS
+
+Downloads data from the WRDS CRSP/Compustat Merged (CCM) links
+database. It allows users to specify the type of links (linktype) and the
+primacy of the link (linkprim).
+
+Usage:
+```r
+download_data_wrds_ccm_links(linktype = c("LU", "LC"), linkprim = c("P", "C"))
+```
+
+Arguments:
+- `linktype`: A character vector indicating the type of link to download.
+The default is c("LU", "LC"), where "LU" stands for "Link Up" and "LC"
+for "Link CRSP".
+- `linkprim`: A character vector indicating the primacy of the link.
+Default is c("P", "C"), where "P" indicates primary and "C" indicates
+conditional links.
+
+Value: A data frame with the columns permno, gvkey, linkdt, and
+linkenddt, where linkenddt is the end date of the link, and missing end
+dates are replaced with today's date.
+
+Examples:
+```r
+ccm_links <- download_data_wrds_ccm_links(linktype = "LU", linkprim = "P")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_ccm_links.R
+
+## download_data_wrds_compustat
+
+Download Data from WRDS Compustat
+
+Downloads financial data from the WRDS Compustat database for a given
+dataset, start date, and end date. It filters the data according to industry
+format, data format, and consolidation level, and returns the most current
+data for each reporting period. Additionally, the annual data also includes
+the calculated book equity (be), operating profitability (op), and
+investment (inv) for each company following Fama & French (1993, 2015), as
+well as income before extraordinary items (ib).
+
+Usage:
+```r
+download_data_wrds_compustat(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  additional_columns = NULL,
+  only_usd = FALSE,
+  only_us = deprecated()
+)
+```
+
+Arguments:
+- `dataset`: The dataset to download ("compustat_annual" or
+"compustat_quarterly").
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, a subset of the dataset is returned.
+- `end_date`: Optional. A character string or Date object in "YYYY-MM-DD"
+format specifying the end date for the data. If not provided, a subset of
+the dataset is returned.
+- `type`: [Deprecated] Use dataset instead.
+- `additional_columns`: Additional columns from the Compustat table as a
+character vector.
+- `only_usd`: A logical indicating whether only USD-denominated shares
+should be returned.
+- `only_us`: [Deprecated] Use only_usd instead.
+
+Value: A data frame with financial data for the specified period,
+including variables for book equity (be), operating profitability (op),
+investment (inv), and others.
+
+Examples:
+```r
+download_data_wrds_compustat("compustat_annual", "2020-01-01", "2020-12-31")
+download_data_wrds_compustat(
+  "compustat_quarterly",
+  "2020-01-01",
+  "2020-12-31"
+)
+
+  # Add additional columns
+download_data_wrds_compustat(
+  "compustat_annual",
+  additional_columns = c("aodo", "aldo")
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_compustat.R
+
+## download_data_wrds_crsp
+
+Download Data from WRDS CRSP
+
+Downloads and processes stock return data from the CRSP database for a
+specified period. Users can choose between monthly and daily datasets.
+The function also adjusts returns for delisting and calculates market
+capitalization and excess returns over the risk-free rate.
+
+Usage:
+```r
+download_data_wrds_crsp(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  type = deprecated(),
+  batch_size = 500,
+  version = "v2",
+  additional_columns = NULL,
+  add_ccm_links = FALSE,
+  adjust_volume = FALSE
+)
+```
+
+Arguments:
+- `dataset`: A string specifying the CRSP dataset to download:
+"crsp_monthly" or "crsp_daily".
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, a subset of the dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, a subset of the dataset is returned.
+- `type`: [Deprecated] Use dataset instead.
+- `batch_size`: An optional integer specifying the batch size for
+processing daily data, with a default of 500.
+- `version`: An optional character specifying which CRSP version to
+use. "v2" (the default) uses the updated second version of CRSP, and
+"v1" downloads the legacy version of CRSP.
+- `additional_columns`: Additional columns from the CRSP monthly or
+daily data as a character vector.
+- `add_ccm_links`: A logical indicating whether CRSP-Compustat links
+should be added automatically using {download_data_wrds_ccm_links()}.
+- `adjust_volume`: A logical indicating whether daily CRSP trading
+volume data should be adjusted according to Gao & Ritter (2010).
+
+Value: A data frame containing CRSP stock returns, adjusted for
+delistings, along with calculated market capitalization and excess returns
+over the risk-free rate. The structure of the returned data frame depends
+on the selected dataset.
+
+Examples:
+```r
+crsp_monthly <- download_data_wrds_crsp(
+  "crsp_monthly",
+  "2020-11-01",
+  "2020-12-31"
+)
+crsp_daily <- download_data_wrds_crsp(
+  "crsp_daily",
+  "2020-12-01",
+  "2020-12-31"
+)
+
+# Add additional columns
+download_data_wrds_crsp(
+  "crsp_monthly",
+  "2020-11-01",
+  "2020-12-31",
+  additional_columns = c("mthvol", "mthvolflg")
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_crsp.R
+
+## download_data_wrds_fisd
+
+Download Filtered FISD Data from WRDS
+
+Establishes a connection to the WRDS database to download a filtered subset
+of the FISD (Fixed Income Securities Database). The function filters the
+fisd_mergedissue and fisd_mergedissuer tables based on several criteria
+related to the securities, such as security level, bond type, coupon type,
+and others, focusing on specific attributes that denote the nature of the
+securities. It finally returns a data frame with selected fields from the
+fisd_mergedissue table after joining it with issuer information from the
+fisd_mergedissuer table for issuers domiciled in the USA.
+
+Usage:
+```r
+download_data_wrds_fisd(additional_columns = NULL)
+```
+
+Arguments:
+- `additional_columns`: Additional columns from the FISD table
+as a character vector.
+
+Value: A data frame containing a subset of FISD data with fields related
+to the bond's characteristics and issuer information. This includes
+complete CUSIP, maturity date, offering amount, offering date, dated date,
+interest frequency, coupon, last interest date, issue ID, issuer ID, and
+SIC code of the issuer.
+
+Examples:
+```r
+fisd <- download_data_wrds_fisd()
+fisd_extended <- download_data_wrds_fisd(
+  additional_columns = c("asset_backed", "defeased")
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_fisd.R
+
+## download_data_wrds_trace_enhanced
+
+Download Enhanced TRACE Data from WRDS
+
+Establishes a connection to the WRDS database to download the specified
+CUSIPs trade messages from the Trade Reporting and Compliance Engine
+(TRACE). The trade data is cleaned as suggested by Dick-Nielsen
+(2009, 2014).
+
+Usage:
+```r
+download_data_wrds_trace_enhanced(cusips, start_date = NULL, end_date = NULL)
+```
+
+Arguments:
+- `cusips`: A character vector specifying the 9-digit CUSIPs to
+download.
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the data. If not
+provided, a subset of the dataset is returned.
+- `end_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the end date for the data. If not
+provided, a subset of the dataset is returned.
+
+Value: A data frame containing the cleaned trade messages from TRACE
+for the selected CUSIPs over the time window specified. Output
+variables include identifying information (i.e., CUSIP, trade
+date/time) and trade-specific information (i.e., price/yield, volume,
+counterparty, and reporting side).
+
+Examples:
+```r
+download_data_wrds_trace_enhanced("00101JAH9", "2019-01-01", "2021-12-31")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_trace_enhanced.R
+
+## get_wrds_connection
+
+Establish a Connection to the WRDS Database
+
+Establishes a connection to the Wharton Research Data Services (WRDS)
+database using the RPostgres package. It requires that the RPostgres
+package be installed and that valid WRDS credentials be set as environment
+variables.
+
+Usage:
+```r
+get_wrds_connection()
+```
+
+Value: An object of class DBIConnection representing the connection
+to the WRDS database. This object can be used with other DBI-compliant
+functions to interact with the database.
+
+Examples:
+```r
+# Before using this function, set your WRDS credentials:
+  # Sys.setenv(WRDS_USER = "your_username", WRDS_PASSWORD = "your_password")
+
+  # con <- get_wrds_connection()
+  # Use `con` with DBI-compliant functions to interact with the WRDS database
+  # Remember to disconnect after use:
+  # disconnect_connection(con)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/get_wrds_connection.R
+
+## set_wrds_credentials
+
+Set WRDS Credentials
+
+Prompts the user to input their WRDS (Wharton Research Data Services)
+username and password, and stores these credentials in a .Renviron file.
+The user can choose to store the .Renviron file in either the project
+directory or the home directory. If the .Renviron file already contains
+WRDS credentials, the user will be asked if they want to overwrite the
+existing credentials. Additionally, the user has the option to add the
+.Renviron file to the .gitignore file to prevent it from being tracked by
+version control.
+
+Usage:
+```r
+set_wrds_credentials()
+```
+
+Value: Invisibly returns TRUE. Displays messages to the user based on
+their input and actions taken.
+
+Examples:
+```r
+set_wrds_credentials()
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/set_wrds_credentials.R
+
+## download_data_pseudo_ccm_links
+
+Generate Pseudo CCM Links
+
+Returns a pseudo CRSP-Compustat linking table with the same column
+layout as {download_data_wrds_ccm_links()}. Every pseudo permno is
+linked to its corresponding gvkey for the full sample horizon.
+
+Usage:
+```r
+download_data_pseudo_ccm_links(
+  n_assets = 1000L,
+  seed = 1234L,
+  linktype = c("LU", "LC"),
+  linkprim = c("P", "C")
+)
+```
+
+Arguments:
+- `n_assets`: Integer. Number of pseudo firms in the universe.
+Defaults to 1000.
+- `seed`: Integer. Random seed controlling the pseudo identifier
+universe; defaults to 1234.
+- `linktype`: Accepted for API compatibility with
+{download_data_wrds_ccm_links()}; ignored for pseudo data.
+- `linkprim`: Accepted for API compatibility with
+{download_data_wrds_ccm_links()}; ignored for pseudo data.
+
+Value: A tibble with columns permno, gvkey, linkdt, and linkenddt,
+one row per pseudo firm.
+
+Examples:
+```r
+download_data_pseudo_ccm_links(n_assets = 10)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_pseudo_ccm_links.R
+
+## download_data_pseudo_compustat
+
+Generate Pseudo Compustat Data
+
+Returns pseudo Compustat data with the same column layout as
+{download_data_wrds_compustat()}. Useful for testing and for reproducing
+the workflow of analyses that rely on Compustat without a WRDS
+subscription. The returned values are simulated and not suitable for
+inference.
+
+Usage:
+```r
+download_data_pseudo_compustat(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  additional_columns = NULL,
+  only_usd = FALSE,
+  n_assets = 1000L,
+  seed = 1234L
+)
+```
+
+Arguments:
+- `dataset`: A string specifying the dataset to simulate. Supported:
+"compustat_annual" and "compustat_quarterly".
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the pseudo panel.
+- `end_date`: Optional. A character string or Date object in "YYYY-MM-DD"
+format specifying the end date for the pseudo panel.
+- `additional_columns`: Additional Compustat columns to include. Filled
+with plausible random draws so call sites that pass additional_columns
+continue to work; the values themselves are not economically meaningful.
+- `only_usd`: Accepted for API compatibility with
+{download_data_wrds_compustat()}; the pseudo universe is treated as
+USD-denominated, so this argument has no effect.
+- `n_assets`: Integer. Number of pseudo firms in the universe.
+Defaults to 1000.
+- `seed`: Integer. Random seed; defaults to 1234. Identical
+(seed, n_assets) produces identical output across calls and matches the
+identifier universe used by {download_data_pseudo_crsp()} and
+{download_data_pseudo_ccm_links()}.
+
+Value: For "compustat_annual", a tibble with columns gvkey, date,
+datadate, the financial-statement variables seq, ceq, at, lt,
+txditc, txdb, itcb, pstkrv, pstkl, pstk, capx, oancf,
+sale, cogs, xint, xsga, ib, curcd, plus the derived be,
+op, at_lag, inv, and any requested additional_columns. For
+"compustat_quarterly", a tibble with columns gvkey, date,
+datadate, atq, ceqq, and any requested additional_columns.
+
+Examples:
+```r
+download_data_pseudo_compustat(
+  "compustat_annual",
+  start_date = "2020-01-01",
+  end_date = "2024-12-31",
+  n_assets = 20
+)
+download_data_pseudo_compustat(
+  "compustat_quarterly",
+  start_date = "2020-01-01",
+  end_date = "2024-12-31",
+  n_assets = 20
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_pseudo_compustat.R
+
+## download_data_pseudo_crsp
+
+Generate Pseudo CRSP Data
+
+Returns pseudo CRSP data with the same column layout as
+{download_data_wrds_crsp()}. Useful for testing and for reproducing the
+workflow of analyses that rely on CRSP without a WRDS subscription. The
+returned values are simulated and not suitable for inference.
+
+Usage:
+```r
+download_data_pseudo_crsp(
+  dataset = NULL,
+  start_date = NULL,
+  end_date = NULL,
+  version = "v2",
+  additional_columns = NULL,
+  add_ccm_links = FALSE,
+  adjust_volume = FALSE,
+  batch_size = 500,
+  n_assets = 1000L,
+  seed = 1234L
+)
+```
+
+Arguments:
+- `dataset`: A string specifying the dataset to simulate. Supported:
+"crsp_monthly" and "crsp_daily".
+- `start_date`: Optional. A character string or Date object in
+"YYYY-MM-DD" format specifying the start date for the pseudo panel.
+- `end_date`: Optional. A character string or Date object in "YYYY-MM-DD"
+format specifying the end date for the pseudo panel.
+- `version`: Accepted for API compatibility with
+{download_data_wrds_crsp()}; the pseudo schema follows the v2 output.
+- `additional_columns`: Additional CRSP columns to include. Filled with
+plausible random draws so call sites that pass additional_columns
+continue to work; the values themselves are not economically meaningful.
+- `add_ccm_links`: A logical indicating whether CRSP-Compustat links
+should be appended. When TRUE, the output gains a gvkey column whose
+values are derived from the same pseudo identifier universe used by
+{download_data_pseudo_ccm_links()}.
+- `adjust_volume`: Accepted for API compatibility with
+{download_data_wrds_crsp()}; ignored for pseudo data.
+- `batch_size`: Accepted for API compatibility with
+{download_data_wrds_crsp()}; ignored for pseudo data.
+- `n_assets`: Integer. Number of pseudo firms in the universe.
+Defaults to 1000.
+- `seed`: Integer. Random seed; defaults to 1234. Identical
+(seed, n_assets) produces identical output across calls and matches the
+identifier universe used by {download_data_pseudo_compustat()} and
+{download_data_pseudo_ccm_links()}.
+
+Value: For "crsp_monthly", a tibble with columns permno, date,
+calculation_date, ret, shrout, prc, primaryexch, siccd,
+listing_age, mktcap, mktcap_lag, exchange, industry, and
+ret_excess. For "crsp_daily", a tibble with columns permno, date,
+ret, and ret_excess. If add_ccm_links = TRUE, a gvkey column is
+appended.
+
+Examples:
+```r
+download_data_pseudo_crsp(
+  "crsp_monthly",
+  start_date = "2020-01-01",
+  end_date = "2024-12-31",
+  n_assets = 20
+)
+download_data_pseudo_crsp(
+  "crsp_daily",
+  start_date = "2020-01-01",
+  end_date = "2020-03-31",
+  n_assets = 20
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_pseudo_crsp.R
+
+## estimate_betas
+
+Estimate Rolling Betas
+
+Estimates rolling betas for a given model using the provided data. It
+supports parallel processing for faster computation using the furrr
+package.
+
+Usage:
+```r
+estimate_betas(
+  data,
+  model,
+  lookback,
+  min_obs = NULL,
+  use_furrr = FALSE,
+  data_options = NULL
+)
+```
+
+Arguments:
+- `data`: A data frame containing the data with a date identifier
+(defaults to date), a stock identifier (defaults to permno), and other
+variables used in the model.
+- `model`: A character string describing the model to be estimated (e.g.,
+"ret_excess ~ mkt_excess + hml + smb").
+- `lookback`: A Period object specifying the number of months, days,
+hours, minutes, or seconds to look back when estimating the rolling model.
+- `min_obs`: An integer specifying the minimum number of observations
+required to estimate the model. Defaults to 80% of lookback.
+- `use_furrr`: A logical indicating whether to use the furrr package
+and its parallelization capabilities. Defaults to FALSE.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The id is used to
+specify the entity (i.e., firm), and the date element is used to specify
+the date column. Uses {data_options()} default if NULL:
+"id" = "permno" and "date" = "date".
+
+Value: A data frame with the estimated betas for each time period.
+
+Examples:
+```r
+# Estimate monthly betas using monthly return data
+set.seed(1234)
+data_monthly <- tibble::tibble(
+  date = rep(seq.Date(from = as.Date("2020-01-01"),
+                      to = as.Date("2020-12-01"), by = "month"), each = 50),
+  permno = rep(1:50, times = 12),
+  ret_excess = rnorm(600, 0, 0.1),
+  mkt_excess = rnorm(600, 0, 0.1),
+  smb = rnorm(600, 0, 0.1),
+  hml = rnorm(600, 0, 0.1),
+)
+
+estimate_betas(data_monthly,  "ret_excess ~ mkt_excess", months(3))
+estimate_betas(
+  data_monthly,
+  "ret_excess ~ mkt_excess + smb + hml",
+  months(6)
+)
+
+data_monthly |>
+  dplyr::rename(id = permno) |>
+  estimate_betas("ret_excess ~ mkt_excess", months(3),
+                 data_options = data_options(id = "id"))
+
+# Estimate monthly betas using daily return data and parallelization
+data_daily <- tibble::tibble(
+  date = rep(seq.Date(from = as.Date("2020-01-01"),
+                      to = as.Date("2020-12-31"), by = "day"), each = 50),
+  permno = rep(1:50, times = 366),
+  ret_excess = rnorm(18300, 0, 0.02),
+  mkt_excess = rnorm(18300, 0, 0.02),
+  smb = rnorm(18300, 0, 0.02),
+  hml = rnorm(18300, 0, 0.02),
+)
+
+data_daily <- data_daily |>
+  dplyr::mutate(date = lubridate::floor_date(date, "month"))
+
+# Change settings via future::plan(strategy = "multisession", workers = 4)
+estimate_betas(
+  data_daily,
+  "ret_excess ~ mkt_excess",
+  lubridate::days(90),
+  use_furrr = TRUE
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/estimate_betas.R
+
+## estimate_fama_macbeth
+
+Estimate Fama-MacBeth Regressions
+
+Estimates Fama-MacBeth regressions (Fama and MacBeth, 1973) by first running
+cross-sectional regressions for each time period and then aggregating the
+results over time to obtain average risk premia and corresponding
+t-statistics.
+
+Usage:
+```r
+estimate_fama_macbeth(
+  data,
+  model,
+  vcov = "newey-west",
+  vcov_options = NULL,
+  data_options = NULL,
+  detail = FALSE
+)
+```
+
+Arguments:
+- `data`: A data frame containing the data for the regression. It must
+include a column representing the time periods (defaults to date) and
+the variables specified in the model.
+- `model`: A character string describing the model to be estimated in
+each cross-section (e.g., "ret_excess ~ beta + bm + log_mktcap").
+- `vcov`: A character string indicating the type of standard errors to
+compute. Options are "iid" for independent and identically distributed
+errors or "newey-west" for Newey-West standard errors. Default is
+"newey-west".
+- `vcov_options`: A list of additional arguments to be passed to the
+NeweyWest() function when vcov = "newey-west". These can include
+options such as lag, which specifies the number of lags to use in the
+Newey-West covariance matrix estimation, and prewhite, which indicates
+whether to apply a prewhitening transformation. Default is an empty list.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The date element is
+used to specify the date column. Uses {data_options()} default if NULL:
+"date" = "date".
+- `detail`: A logical value indicating whether to return additional
+summary statistics. If FALSE (default), the function returns only the
+coefficient estimates. If TRUE, it returns a list with two elements:
+coefficients (the usual estimates table) and summary_statistics (a
+one-row tibble with the average cross-sectional R-squared and the average
+number of observations per cross-section).
+
+Value: If detail = FALSE (default), a tibble with columns
+factor, risk_premium, n (number of time periods),
+standard_error, and t_statistic.
+
+If detail = TRUE, a named list with two elements:
+\describe{
+\item{coefficients}{The same tibble described above.}
+\item{summary_statistics}{A one-row tibble with r_squared (mean
+cross-sectional R-squared) and n_obs (mean cross-sectional
+observation count).}
+}
+
+Examples:
+```r
+set.seed(1234)
+
+data <- tibble::tibble(
+  date = rep(seq.Date(from = as.Date("2020-01-01"),
+                      to = as.Date("2020-12-01"), by = "month"), each = 50),
+  permno = rep(1:50, times = 12),
+  ret_excess = rnorm(600, 0, 0.1),
+  beta = rnorm(600, 1, 0.2),
+  bm = rnorm(600, 0.5, 0.1),
+  log_mktcap = rnorm(600, 10, 1)
+)
+
+estimate_fama_macbeth(data, "ret_excess ~ beta + bm + log_mktcap")
+estimate_fama_macbeth(
+  data,
+  "ret_excess ~ beta + bm + log_mktcap",
+  vcov = "iid"
+)
+estimate_fama_macbeth(
+  data,
+  "ret_excess ~ beta + bm + log_mktcap",
+  vcov = "newey-west",
+  vcov_options = list(lag = 6, prewhite = FALSE)
+)
+
+# Return detailed output including R-squared and observation counts
+estimate_fama_macbeth(
+  data,
+  "ret_excess ~ beta + bm + log_mktcap",
+  detail = TRUE
+)
+
+# Use different column name for date
+data |>
+  dplyr::rename(month = date) |>
+  estimate_fama_macbeth(
+    "ret_excess ~ beta + bm + log_mktcap",
+    data_options = data_options(date = "month")
+ )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/estimate_fama_macbeth.R
+
+## estimate_model
+
+Estimate a Linear Model
+
+Estimates a linear model specified by one or more independent
+variables. It checks for the presence of the specified independent variables
+in the dataset and whether the dataset has a sufficient number of
+observations. Depending on the output parameter, it returns the model's
+coefficients, t-statistics, residuals, or any combination in a named list.
+
+Usage:
+```r
+estimate_model(data, model, min_obs = 1, output = "coefficients")
+```
+
+Arguments:
+- `data`: A data frame containing the dependent variable and one or more
+independent variables.
+- `model`: A character that describes the model to be estimated (e.g.,
+"ret_excess ~ mkt_excess + hml + smb").
+- `min_obs`: The minimum number of observations required to estimate the
+model. Defaults to 1.
+- `output`: A character vector specifying what to return. Must contain one
+or more of "coefficients" (default), "residuals", and "tstats". If a
+single value is provided, the corresponding object is returned directly.
+If multiple values are provided, a named list is returned.
+
+Value: If output contains a single value: a data frame of coefficients
+or t-statistics, or a numeric vector of residuals. If output contains
+multiple values: a named list with the requested elements. Coefficients
+and t-statistics are returned as data frames with column names
+corresponding to the model terms. Residuals are returned as a numeric
+vector of length nrow(data) with NA for rows with missing data or
+insufficient observations.
+
+Examples:
+```r
+set.seed(42)
+data <- data.frame(
+  ret_excess = rnorm(100),
+  mkt_excess = rnorm(100),
+  smb = rnorm(100),
+  hml = rnorm(100)
+)
+
+# Estimate model with a single independent variable
+estimate_model(data, "ret_excess ~ mkt_excess")
+
+# Estimate model with multiple independent variables
+estimate_model(data, "ret_excess ~ mkt_excess + smb + hml")
+
+# Estimate model without intercept
+estimate_model(data, "ret_excess ~ mkt_excess - 1")
+
+# Calculate residuals
+estimate_model(data, "ret_excess ~ mkt_excess + smb + hml",
+  output = "residuals"
+)
+
+# Return t-statistics
+estimate_model(data, "ret_excess ~ mkt_excess + smb + hml",
+  output = "tstats"
+)
+
+# Return coefficients, t-statistics, and residuals
+estimate_model(data, "ret_excess ~ mkt_excess + smb + hml",
+  output = c("coefficients", "tstats", "residuals")
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/estimate_model.R
+
+## assign_portfolio
+
+Assign Portfolios Based on Sorting Variable
+
+Assigns data points to portfolios based on a specified sorting variable and
+the selected function to compute breakpoints. Users can specify a function
+to compute breakpoints. The function must take data and
+sorting_variable as the first two arguments. Additional arguments are
+passed with a named list {breakpoint_options()}. The function needs to
+return an ascending vector of breakpoints. By default, breakpoints are
+computed with {compute_breakpoints()}. The default column names can be
+modified using {data_options()}.
+
+Usage:
+```r
+assign_portfolio(
+  data,
+  sorting_variable,
+  breakpoint_options = NULL,
+  breakpoint_function = compute_breakpoints,
+  data_options = NULL
+)
+```
+
+Arguments:
+- `data`: A data frame containing the dataset for portfolio assignment.
+- `sorting_variable`: A string specifying the column name in data to be
+used for sorting and determining portfolio assignments based on the
+breakpoints.
+- `breakpoint_options`: An optional named list of arguments passed to
+breakpoint_function.
+- `breakpoint_function`: A function to compute breakpoints. The default
+is set to {compute_breakpoints()}.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. Passed through to
+breakpoint_function. When using the default {compute_breakpoints()},
+the exchange element is used to specify the exchange column, and
+mktcap_lag is used to specify the market capitalization column. Uses
+{data_options()} default if NULL: "exchange" = "exchange" and
+"mktcap_lag" = "mktcap_lag".
+
+Value: A vector of integer portfolio assignments for each row in the
+input data.
+
+Examples:
+```r
+set.seed(42)
+data <- data.frame(
+  id = 1:100,
+  exchange = sample(c("NYSE", "NASDAQ"), 100, replace = TRUE),
+  market_cap = 1:100
+)
+
+assign_portfolio(data, "market_cap", breakpoint_options(n_portfolios = 5))
+
+assign_portfolio(
+  data,
+  "market_cap",
+  breakpoint_options(
+    percentiles = c(0.2, 0.4, 0.6, 0.8),
+    breakpoints_exchanges = c("NYSE")
+  )
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/assign_portfolio.R
+
+## breakpoint_options
+
+Create Breakpoint Options for Portfolio Sorting
+
+Generates a structured list of options for defining breakpoints in
+portfolio sorting. It includes parameters for the number of portfolios,
+percentile thresholds, exchange-specific breakpoints, and smooth bunching,
+along with additional optional parameters.
+
+Usage:
+```r
+breakpoint_options(
+  n_portfolios = NULL,
+  percentiles = NULL,
+  breakpoints_exchanges = NULL,
+  smooth_bunching = FALSE,
+  breakpoints_min_size_threshold = NULL,
+  ...
+)
+```
+
+Arguments:
+- `n_portfolios`: Integer, optional. The number of portfolios to create.
+Must be a positive integer. If not provided, defaults to NULL.
+- `percentiles`: Numeric vector, optional. A vector of percentile
+thresholds for defining breakpoints. Each value must be between 0 and 1.
+If not provided, defaults to NULL.
+- `breakpoints_exchanges`: Character vector, optional. A non-empty vector
+specifying the exchange from which to compute the breakpoints. If not
+provided, defaults to NULL.
+- `smooth_bunching`: Logical, optional. Indicates whether smooth bunching
+should be applied. Defaults to FALSE.
+- `breakpoints_min_size_threshold`: Numeric, optional. When set to a value
+between 0 and 1, stocks with market capitalization below this quantile are
+excluded from breakpoint computation. The quantile is computed among
+breakpoints_exchanges stocks if specified, otherwise among all stocks.
+Requires a market capitalization column in the data (see
+{data_options()}). Defaults to NULL (no size filtering).
+- `...`: Additional optional arguments. These will be captured in the
+resulting structure as a list.
+
+Value: A list of class "tidyfinance_breakpoint_options" containing the
+provided breakpoint options, including any additional arguments passed
+via ....
+
+Examples:
+```r
+breakpoint_options(
+  n_portfolios = 5,
+  percentiles = c(0.2, 0.4, 0.6, 0.8),
+  breakpoints_exchanges = "NYSE",
+  smooth_bunching = TRUE,
+  custom_threshold = 0.5,
+  another_option = "example"
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/breakpoint_options.R
+
+## compute_breakpoints
+
+Compute Breakpoints Based on Sorting Variable
+
+Computes breakpoints based on a specified sorting. It can optionally filter
+the data by exchanges or lagged size quantiles before computing the
+breakpoints. The function requires either the number of portfolios to be
+created or specific percentiles for the breakpoints, but not both. The
+function also optionally handles cases where the sorting variable clusters
+on the edges, by assigning all extreme values to the edges and attempting
+to compute equally populated breakpoints with the remaining values.
+
+Usage:
+```r
+compute_breakpoints(
+  data,
+  sorting_variable,
+  breakpoint_options,
+  data_options = NULL
+)
+```
+
+Arguments:
+- `data`: A data frame containing the dataset for breakpoint computation.
+- `sorting_variable`: A character string specifying the column name in
+data to be used for determining breakpoints.
+- `breakpoint_options`: A named list of {breakpoint_options()} for the
+breakpoints. The arguments include
+\itemize{
+\item n_portfolios An optional integer specifying the number of
+equally sized portfolios to create. This parameter is mutually
+exclusive with percentiles.
+\item percentiles An optional numeric vector specifying the
+percentiles for determining the breakpoints of the portfolios.
+This parameter is mutually exclusive with n_portfolios.
+\item breakpoints_exchanges An optional character vector specifying
+exchange names to filter the data before computing breakpoints.
+Exchanges must be stored in a column given by data_options (defaults
+to exchange). If NULL, no filtering is applied.
+\item smooth_bunching An optional logical parameter specifying if
+to attempt smoothing non-extreme portfolios if the sorting variable
+bunches on the extremes (TRUE), or not (FALSE, the default).
+In some cases, smoothing will not result in equal-sized portfolios
+off the edges due to multiple clusters. If sufficiently large
+bunching is detected, percentiles is ignored and equally-spaced
+portfolios are returned for these cases with a warning.
+\item breakpoints_min_size_threshold An optional numeric value between
+0 and 1 (exclusive). When set, stocks with market capitalization below
+this quantile are excluded from breakpoint computation. The quantile
+is computed among breakpoints_exchanges stocks if specified,
+otherwise among all stocks. Requires a market capitalization column
+in the data (column name determined by data_options).
+}
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The exchange element
+is used to specify the exchange column, and mktcap_lag is used to
+specify the market capitalization. Uses {data_options()} default if
+NULL: "exchange" = "exchange" and "mktcap_lag" = "mktcap_lag".
+
+Value: A numeric vector of breakpoints of the desired length.
+
+Examples:
+```r
+set.seed(42)
+data <- data.frame(
+  id = 1:100,
+  exchange = sample(c("NYSE", "NASDAQ"), 100, replace = TRUE),
+  market_cap = 1:100
+)
+
+compute_breakpoints(data, "market_cap", breakpoint_options(n_portfolios = 5))
+compute_breakpoints(
+  data,
+  "market_cap",
+  breakpoint_options(
+    percentiles = c(0.2, 0.4, 0.6, 0.8),
+    breakpoints_exchanges = c("NYSE")
+  )
+ )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_breakpoints.R
+
+## compute_long_short_returns
+
+Compute Long-Short Returns
+
+Calculates long-short returns based on the returns of portfolios. The
+long-short return is computed as the difference between the returns of the
+"top" and "bottom" portfolios. The direction of the calculation can be
+adjusted based on whether the return from the "bottom" portfolio is
+subtracted from or added to the return from the "top" portfolio.
+
+Usage:
+```r
+compute_long_short_returns(
+  data,
+  direction = "top_minus_bottom",
+  data_options = NULL
+)
+```
+
+Arguments:
+- `data`: A data frame containing portfolio returns. The data frame must
+include columns for the portfolio identifier, date, and return
+measurements (as specified in data_options).
+- `direction`: A character string specifying the direction of the
+long-short return calculation. It can be either "top_minus_bottom" or
+"bottom_minus_top". Default is "top_minus_bottom". If set to
+"bottom_minus_top", the return will be computed as (bottom - top).
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The date element is
+used to specify the date column, the ret_excess element is used to
+specify the excess return column, and portfolio is used to specify the
+assigned portfolio. Uses {data_options()} default if NULL:
+"date" = "date", "ret_excess" = "ret_excess", and
+"portfolio" = "portfolio".
+
+Value: A data frame with columns for date, return measurement types (from
+the "ret_measure" column), and the computed long-short returns. The data
+frame is arranged by date and pivoted to have return measurement types as
+columns with their corresponding long-short returns.
+
+Examples:
+```r
+set.seed(42)
+data <- data.frame(
+  permno = 1:100,
+  date = rep(
+    seq.Date(from = as.Date("2020-01-01"), by = "month", length.out = 100),
+    each = 10
+  ),
+  mktcap_lag = runif(100, 100, 1000),
+  ret_excess = rnorm(100),
+  size = runif(100, 50, 150)
+)
+
+portfolio_returns <- compute_portfolio_returns(
+  data, "size", "univariate",
+  breakpoint_options_main = breakpoint_options(n_portfolios = 5)
+)
+
+compute_long_short_returns(portfolio_returns)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_long_short_returns.R
+
+## compute_portfolio_returns
+
+Compute Portfolio Returns
+
+Computes individual portfolio returns based on specified sorting variables
+and sorting methods. The portfolios can be rebalanced every period or on an
+annual frequency by specifying a rebalancing month, which is only applicable
+at a monthly return frequency. The function supports univariate and
+bivariate sorts, with the latter supporting dependent and independent
+sorting methods.
+
+Usage:
+```r
+compute_portfolio_returns(
+  data,
+  sorting_variables,
+  sorting_method,
+  rebalancing_month = NULL,
+  breakpoint_options_main,
+  breakpoint_options_secondary = NULL,
+  breakpoint_function_main = compute_breakpoints,
+  breakpoint_function_secondary = compute_breakpoints,
+  min_portfolio_size = 1L,
+  cap_weight = 0.8,
+  data_options = NULL,
+  quiet = FALSE
+)
+```
+
+Arguments:
+- `data`: A data frame containing the dataset for portfolio assignment
+and return computation. The panel data must include individual stock
+identifiers and the time point. It must contain columns for the sorting
+variables and excess returns. Additionally, lagged market capitalization
+is required for value-weighted returns (see parameter data_options).
+- `sorting_variables`: A character vector specifying the column names in
+data to be used for sorting and determining portfolio assignments. For
+univariate sorts, provide a single variable. For bivariate sorts, provide
+two variables, where the first string refers to the main variable and the
+second string refers to the secondary ("control") variable.
+- `sorting_method`: A string specifying the sorting method to be used.
+Possible values are:
+\itemize{
+\item "univariate": For a single sorting variable.
+\item "bivariate-dependent": For two sorting variables, where the
+main sort depends on the secondary variable.
+\item "bivariate-independent": For two independent sorting variables.
+}
+For bivariate sorts, the portfolio returns are averaged over the
+controlling sorting variable (i.e., the second sorting variable), and only
+portfolio returns for the main sorting variable (given as the first
+element of sorting_variables) are returned.
+- `rebalancing_month`: An integer between 1 and 12 specifying the month
+in which to form portfolios that are held constant for one year. For
+example, setting it to 7 creates portfolios in July that are held
+constant until June of the following year. The default NULL corresponds
+to periodic rebalancing.
+- `breakpoint_options_main`: A named list of {breakpoint_options()}
+passed to breakpoint_function_main for the main sorting variable.
+- `breakpoint_options_secondary`: An optional named list of
+{breakpoint_options()} passed to breakpoint_function_secondary.
+- `breakpoint_function_main`: A function to compute the breakpoints for
+the main sorting variable. The default is set to {compute_breakpoints()}.
+- `breakpoint_function_secondary`: A function to compute the breakpoints
+for the secondary sorting variable. The default is set to
+{compute_breakpoints()}.
+- `min_portfolio_size`: An integer specifying the minimum number of
+firms required in the reported portfolio cross-section on a given date
+(default 1L, i.e. at least one observation per reported portfolio).
+For both univariate and bivariate sorts the threshold is applied to the
+firm count per (portfolio, date) of the reported cross-section: for
+univariate sorts that is firms per portfolio-date; for bivariate sorts
+that is firms per main-portfolio-date summed across the secondary
+buckets. Cross-sections below the threshold have their returns set to
+NA. A typical value is 5L (the Fama-French convention). Set to 0L
+to deactivate the check entirely.
+- `cap_weight`: A numeric value between 0 and 1 specifying the percentile
+at which market capitalization is capped per date when computing capped
+value-weighted excess returns (i.e., ret_excess_vw_capped). Defaults to
+0.8.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The id element is
+used to specify the entity (i.e., firm), date is used to specify the
+date column, ret_excess is used to specify the excess return column, and
+mktcap_lag is used to specify the market capitalization. Uses
+{data_options()} default if NULL: "id" = "permno",
+"date" = "date", "ret_excess" = "ret_excess", and
+"mktcap_lag" = "mktcap_lag".
+- `quiet`: A logical value indicating whether to suppress informational
+messages about missing values in the output panel (default is FALSE).
+
+Value: A data frame with computed portfolio returns as a complete panel
+(all portfolio-date combinations), containing the following columns:
+\itemize{
+\item portfolio: The portfolio identifier.
+\item date: The date of the portfolio return.
+\item ret_excess_vw: The value-weighted excess return of the
+portfolio (only computed if data contains a lagged market
+capitalization column specified by data_options(), which defaults
+to mktcap_lag). NA if insufficient observations for that
+portfolio-date.
+\item ret_excess_ew: The equal-weighted excess return of the
+portfolio. NA if insufficient observations for that portfolio-date.
+\item ret_excess_vw_capped: The capped value-weighted excess return
+of the portfolio (only computed if data contains a lagged market
+capitalization column specified by data_options(), which defaults
+to mktcap_lag). Weights are computed using market capitalization
+capped at the cap_weight percentile per date. NA if insufficient
+observations for that portfolio-date.
+}
+
+Examples:
+```r
+set.seed(42)
+# Univariate sorting with periodic rebalancing
+data <- data.frame(
+  permno = 1:500,
+  date = rep(
+    seq.Date(
+      from = as.Date("2020-01-01"),
+      by = "month",
+      length.out = 100
+    ),
+    each = 10
+  ),
+  mktcap_lag = runif(500, 100, 1000),
+  ret_excess = rnorm(500),
+  size = runif(500, 50, 150)
+)
+
+compute_portfolio_returns(
+  data, "size", "univariate",
+  breakpoint_options_main = breakpoint_options(n_portfolios = 5)
+)
+
+# Bivariate dependent sorting with annual rebalancing
+compute_portfolio_returns(
+  data, c("size", "mktcap_lag"), "bivariate-dependent", 7,
+  breakpoint_options_main = breakpoint_options(n_portfolios = 5),
+  breakpoint_options_secondary = breakpoint_options(n_portfolios = 3),
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_portfolio_returns.R
+
+## data_options
+
+Create Data Options
+
+Creates a list of data options of class tidyfinance_data_options used for
+TidyFinance-related functions. These options map the specific data variables
+to the TidyFinance naming conventions, allowing functions to flexibly work
+with different datasets by specifying the relevant column names. Additional
+options can be passed through ....
+
+Usage:
+```r
+data_options(
+  id = "permno",
+  date = "date",
+  exchange = "exchange",
+  mktcap_lag = "mktcap_lag",
+  ret_excess = "ret_excess",
+  portfolio = "portfolio",
+  siccd = "siccd",
+  price = "prc_adj",
+  listing_age = "listing_age",
+  be = "be",
+  earnings = "ib",
+  ...
+)
+```
+
+Arguments:
+- `id`: A character string representing the entity variable (defaults to
+"permno").
+- `date`: A character string representing the date variable (defaults to
+"date").
+- `exchange`: A character string representing the exchange variable
+(defaults to "exchange").
+- `mktcap_lag`: A character string representing the market capitalization
+lag variable (defaults to "mktcap_lag").
+- `ret_excess`: A character string representing the excess return variable
+(defaults to "ret_excess").
+- `portfolio`: A character string representing the portfolio variable
+(defaults to "portfolio").
+- `siccd`: A character string representing the Standard Industrial
+Classification code variable (defaults to "siccd").
+- `price`: A character string representing the (adjusted) price variable
+(defaults to "prc_adj").
+- `listing_age`: A character string representing the listing age variable
+(defaults to "listing_age").
+- `be`: A character string representing the book equity variable (defaults
+to "be").
+- `earnings`: A character string representing the earnings variable
+(defaults to "ib", the Compustat income before extraordinary items
+column).
+- `...`: Additional arguments to be included in the data options list.
+
+Value: A list of class tidyfinance_data_options containing the specified
+data options.
+
+Examples:
+```r
+data_options(
+  id = "permno",
+  date = "date",
+  exchange = "exchange"
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/data_options.R
+
+## filter_options
+
+Create Filter Options
+
+Creates a list of filter options of class tidyfinance_filter_options used
+for sample construction in TidyFinance-related functions. These options
+control which observations are retained before portfolio sorting.
+
+Usage:
+```r
+filter_options(
+  exclude_financials = FALSE,
+  exclude_utilities = FALSE,
+  min_stock_price = NULL,
+  min_size_quantile = NULL,
+  min_listing_age = NULL,
+  exclude_negative_book_equity = FALSE,
+  exclude_negative_earnings = FALSE,
+  ...
+)
+```
+
+Arguments:
+- `exclude_financials`: A logical indicating whether to exclude financial
+firms (SIC codes 6000–6799). Defaults to FALSE.
+- `exclude_utilities`: A logical indicating whether to exclude utility
+firms (SIC codes 4900–4999). Defaults to FALSE.
+- `min_stock_price`: A single positive numeric specifying the minimum
+stock price required to include an observation. NULL (the default)
+applies no price filter.
+- `min_size_quantile`: A single numeric strictly between 0 and 1
+specifying the minimum cross-sectional size quantile (based on lagged
+market cap) required to include an observation. NULL (the default)
+applies no size quantile filter. The cutoff is computed from NYSE
+stocks only. This requires an exchange column in the data (as
+mapped via {data_options()}); an error is raised if it is missing.
+- `min_listing_age`: A single non-negative integer or numeric specifying
+the minimum number of months a stock must have been listed in CRSP.
+NULL (the default) applies no listing age filter.
+- `exclude_negative_book_equity`: A logical indicating whether to exclude
+observations with non-positive book equity. Defaults to FALSE.
+- `exclude_negative_earnings`: A logical indicating whether to exclude
+observations with non-positive earnings. Defaults to FALSE.
+- `...`: Additional arguments to be included in the filter options list.
+
+Value: A list of class tidyfinance_filter_options containing the
+specified filter options.
+
+Examples:
+```r
+filter_options(
+  exclude_financials = TRUE,
+  exclude_utilities = TRUE,
+  min_stock_price = 1,
+  min_listing_age = 12
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/filter_options.R
+
+## filter_sorting_data
+
+Filter Sorting Data
+
+Applies sample construction filters to a data frame before portfolio
+sorting. Filters are applied in a fixed order: financials exclusion,
+utilities exclusion, minimum stock price, minimum size quantile, minimum
+listing age, positive book equity, and positive earnings. An informational
+message is emitted for each filter that actually removes at least one
+observation.
+
+Usage:
+```r
+filter_sorting_data(
+  data,
+  filter_options = NULL,
+  data_options = NULL,
+  quiet = FALSE
+)
+```
+
+Arguments:
+- `data`: A data frame containing the stock-level panel data to be
+filtered.
+- `filter_options`: A list of class tidyfinance_filter_options created
+by {filter_options()}. If NULL (the default), the defaults from
+{filter_options()} are used (i.e., no filters are applied). The arguments
+accepted by {filter_options()} include
+\itemize{
+\item exclude_financials A logical indicating whether to exclude
+financial firms (SIC codes 6000–6799). Defaults to FALSE.
+\item exclude_utilities A logical indicating whether to exclude
+utility firms (SIC codes 4900–4999). Defaults to FALSE.
+\item min_stock_price A single positive numeric specifying the
+minimum stock price required to include an observation. NULL (the
+default) applies no price filter.
+\item min_size_quantile A single numeric strictly between 0 and 1
+specifying the minimum cross-sectional size quantile (based on lagged
+market cap) required to include an observation. NULL (the default)
+applies no size quantile filter. The cutoff is computed from NYSE
+stocks only; the exchange column (mapped via {data_options()})
+must be present in the data or an error is raised.
+\item min_listing_age A single non-negative integer or numeric
+specifying the minimum number of months a stock must have been listed
+in CRSP. NULL (the default) applies no listing age filter.
+\item exclude_negative_book_equity A logical indicating whether to
+exclude observations with non-positive book equity. Defaults to
+FALSE.
+\item exclude_negative_earnings A logical indicating whether to
+exclude observations with non-positive earnings. Defaults to FALSE.
+}
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The siccd element is
+used to specify the SIC code column, price is used to specify the
+(adjusted) price column, mktcap_lag is used to specify the market
+capitalization column, date is used to specify the date column,
+listing_age is used to specify the listing age column, be is used to
+specify the book equity column, and earnings is used to specify the
+earnings column. Uses {data_options()} default if NULL:
+"siccd" = "siccd", "price" = "prc_adj", "exchange" = "exchange"
+"mktcap_lag" = "mktcap_lag", "date" = "date",
+"listing_age" = "listing_age", "be" = "be", and "earnings" = "ib".
+- `quiet`: A logical indicating whether informational messages should be
+suppressed. Defaults to FALSE.
+
+Value: The filtered data frame, preserving the class and structure of the
+input.
+
+Examples:
+```r
+data <- data.frame(
+  permno = 1:5,
+  date = as.Date("2020-01-01"),
+  siccd = c(6100, 2000, 4950, 3000, 6500),
+  prc_adj = c(5, 0.5, 15, 20, 10)
+)
+
+data |>
+  filter_sorting_data(
+    filter_options = filter_options(
+      exclude_financials = TRUE,
+      min_stock_price = 1
+    )
+  )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/filter_sorting_data.R
+
+## implement_portfolio_sort
+
+Implement Portfolio Sort
+
+A convenience wrapper that combines sample construction filtering and
+portfolio return computation into a single call. Equivalent to calling
+{filter_sorting_data()} followed by {compute_portfolio_returns()}.
+
+Usage:
+```r
+implement_portfolio_sort(
+  data,
+  sorting_variables,
+  sorting_method,
+  rebalancing_month = NULL,
+  portfolio_sort_options,
+  breakpoint_function_main = compute_breakpoints,
+  breakpoint_function_secondary = compute_breakpoints,
+  min_portfolio_size = 1L,
+  cap_weight = 0.8,
+  data_options = NULL,
+  quiet = FALSE
+)
+```
+
+Arguments:
+- `data`: A data frame containing the stock-level panel data.
+- `sorting_variables`: A character vector of one or two column names to
+sort portfolios on.
+- `sorting_method`: A string specifying the sorting method:
+"univariate", "bivariate-dependent", or "bivariate-independent".
+- `rebalancing_month`: An optional integer specifying the month in which
+portfolios are rebalanced annually. NULL (the default) means monthly
+rebalancing.
+- `portfolio_sort_options`: A list of class
+tidyfinance_portfolio_sort_options created by
+{portfolio_sort_options()}, bundling filter and breakpoint
+specifications. The arguments accepted by {portfolio_sort_options()}
+include
+\itemize{
+\item filter_options A list of class tidyfinance_filter_options
+created by {filter_options()}, or NULL (the default, which applies
+no filters). Options include exclude_financials,
+exclude_utilities, min_stock_price, min_size_quantile,
+min_listing_age, exclude_negative_book_equity, and
+exclude_negative_earnings.
+\item breakpoint_options_main A list of class
+tidyfinance_breakpoint_options created by {breakpoint_options()},
+specifying breakpoints for the primary sorting variable. Options
+include n_portfolios, percentiles, breakpoints_exchanges,
+smooth_bunching, and breakpoints_min_size_threshold.
+\item breakpoint_options_secondary A list of class
+tidyfinance_breakpoint_options created by {breakpoint_options()},
+specifying breakpoints for the secondary sorting variable, or NULL
+(the default) for univariate sorts. Options are the same as for
+breakpoint_options_main.
+}
+- `breakpoint_function_main`: The function used to compute breakpoints for
+the main sorting variable. Defaults to {compute_breakpoints()}.
+- `breakpoint_function_secondary`: The function used to compute breakpoints
+for the secondary sorting variable. Defaults to {compute_breakpoints()}.
+- `min_portfolio_size`: An integer specifying the minimum number of
+firms in the reported portfolio cross-section on a given date. Defaults
+to 1L (at least one observation per reported portfolio). For univariate
+sorts that is firms per portfolio-date; for bivariate sorts that is firms
+per main-portfolio-date summed across the secondary buckets.
+Cross-sections below the threshold have their returns set to NA.
+Set to 0L to deactivate the check. See {compute_portfolio_returns()}.
+- `cap_weight`: A numeric between 0 and 1 specifying the quantile at which
+portfolio weights are capped for the capped value-weighted return.
+Defaults to 0.8.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. All elements are
+forwarded to {filter_sorting_data()} and {compute_portfolio_returns()}.
+Uses {data_options()} default if NULL: "id" = "permno",
+"date" = "date", "exchange" = "exchange",
+"mktcap_lag" = "mktcap_lag", "ret_excess" = "ret_excess",
+"siccd" = "siccd", "price" = "prc_adj",
+"listing_age" = "listing_age", "be" = "be", and
+"earnings" = "ib".
+- `quiet`: A logical indicating whether informational messages should be
+suppressed. Defaults to FALSE.
+
+Value: A data frame of portfolio returns as returned by
+{compute_portfolio_returns()}.
+
+Examples:
+```r
+set.seed(123)
+data <- data.frame(
+  permno = 1:500,
+  date = rep(
+    seq.Date(
+      from = as.Date("2020-01-01"),
+      by = "month",
+      length.out = 100
+    ),
+    each = 10
+  ),
+  mktcap_lag = runif(500, 100, 1000),
+  ret_excess = rnorm(500),
+  prc_adj = runif(500, 0.5, 50),
+  size = runif(500, 50, 150)
+)
+implement_portfolio_sort(
+  data = data,
+  sorting_variables = "size",
+  sorting_method = "univariate",
+  portfolio_sort_options = portfolio_sort_options(
+    filter_options = filter_options(
+      min_stock_price = 1
+    ),
+    breakpoint_options_main = breakpoint_options(n_portfolios = 5)
+  )
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/implement_portfolio_sort.R
+
+## portfolio_sort_options
+
+Create Portfolio Sort Options
+
+Creates a list of options of class tidyfinance_portfolio_sort_options that
+bundles sample construction filters and breakpoint specifications for use
+with {implement_portfolio_sort()}.
+
+Usage:
+```r
+portfolio_sort_options(
+  filter_options = NULL,
+  breakpoint_options_main,
+  breakpoint_options_secondary = NULL,
+  ...
+)
+```
+
+Arguments:
+- `filter_options`: A list of class tidyfinance_filter_options created
+by {filter_options()}, or NULL (the default, which applies no filters).
+The arguments accepted by {filter_options()} include
+\itemize{
+\item exclude_financials A logical indicating whether to exclude
+financial firms (SIC codes 6000–6799). Defaults to FALSE.
+\item exclude_utilities A logical indicating whether to exclude
+utility firms (SIC codes 4900–4999). Defaults to FALSE.
+\item min_stock_price A single positive numeric specifying the
+minimum stock price required to include an observation. NULL (the
+default) applies no price filter.
+\item min_size_quantile A single numeric strictly between 0 and 1
+specifying the minimum cross-sectional size quantile (based on lagged
+market cap) required to include an observation. NULL (the default)
+applies no size quantile filter.
+\item min_listing_age A single non-negative integer or numeric
+specifying the minimum number of months a stock must have been listed
+in CRSP. NULL (the default) applies no listing age filter.
+\item exclude_negative_book_equity A logical indicating whether to
+exclude observations with non-positive book equity. Defaults to
+FALSE.
+\item exclude_negative_earnings A logical indicating whether to
+exclude observations with non-positive earnings. Defaults to FALSE.
+}
+- `breakpoint_options_main`: A list of class
+tidyfinance_breakpoint_options created by {breakpoint_options()},
+specifying breakpoints for the primary sorting variable. The arguments
+accepted by {breakpoint_options()} include
+\itemize{
+\item n_portfolios An optional integer specifying the number of
+equally sized portfolios to create. This parameter is mutually
+exclusive with percentiles.
+\item percentiles An optional numeric vector specifying the
+percentiles for determining the breakpoints of the portfolios.
+This parameter is mutually exclusive with n_portfolios.
+\item breakpoints_exchanges An optional character vector specifying
+exchange names to filter the data before computing breakpoints.
+Exchanges must be stored in a column given by data_options (defaults
+to exchange). If NULL, no filtering is applied.
+\item smooth_bunching An optional logical parameter specifying if
+to attempt smoothing non-extreme portfolios if the sorting variable
+bunches on the extremes (TRUE), or not (FALSE, the default).
+\item breakpoints_min_size_threshold An optional numeric value between
+0 and 1 (exclusive). When set, stocks with market capitalization below
+this quantile are excluded from breakpoint computation.
+}
+- `breakpoint_options_secondary`: A list of class
+tidyfinance_breakpoint_options created by {breakpoint_options()},
+specifying breakpoints for the secondary sorting variable, or NULL
+(the default) for univariate sorts. The arguments accepted by
+{breakpoint_options()} are the same as for breakpoint_options_main.
+- `...`: Additional arguments to be included in the options list.
+
+Value: A list of class tidyfinance_portfolio_sort_options containing
+the specified options.
+
+Examples:
+```r
+portfolio_sort_options(
+  filter_options = filter_options(exclude_financials = TRUE),
+  breakpoint_options_main = breakpoint_options(n_portfolios = 10)
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/portfolio_sort_options.R
+
+## add_lagged_columns
+
+Add Lagged Columns via Join
+
+Appends lagged versions of specified columns to a data frame using a
+join-based approach.
+
+Usage:
+```r
+add_lagged_columns(
+  data,
+  cols,
+  lag,
+  max_lag = lag,
+  by = NULL,
+  drop_na = FALSE,
+  ff_adjustment = FALSE,
+  data_options = NULL
+)
+```
+
+Arguments:
+- `data`: A data frame containing the variables to lag.
+- `cols`: A character vector specifying the names of the columns to be
+lagged. Each column produces a new column suffixed with _lag.
+- `lag`: An integer or a lubridate::periods() object, e.g.,
+months(1), specifying the minimum lag (inclusive) to apply.
+- `max_lag`: An integer or a lubridate::periods() object specifying
+the maximum lag (inclusive) to apply. Defaults to lag (exact lag).
+- `by`: An optional character vector specifying grouping columns
+(e.g., a stock identifier). Lagged values are matched within groups.
+Defaults to NULL.
+- `drop_na`: A logical value. If TRUE, NA values in the source
+columns are excluded before matching, so the lookup skips over missing
+observations. Applied independently per column. Defaults to FALSE.
+- `ff_adjustment`: A logical value. If TRUE, only the last observation
+per year (within each group defined by by) is retained as a source for
+lagged values, following Fama-French conventions for annual accounting
+data. Defaults to FALSE.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The date element is
+used to specify the date column. Uses {data_options()} default if NULL:
+"date" = "date".
+
+Value: A data frame with the same rows as data and new columns appended,
+each suffixed with _lag. Unmatched rows receive NA in the lagged
+columns.
+
+Examples:
+```r
+set.seed(42)
+data <- tibble::tibble(
+  permno = rep(1:2, each = 10),
+  date = rep(
+    seq.Date(as.Date("2023-01-01"), by = "month", length.out = 10),
+    2
+  ),
+  size = runif(20, 100, 200),
+  bm = runif(20, 0.5, 1.5)
+)
+
+# Exact lag: each row gets the value from exactly 2 months earlier
+add_lagged_columns(
+  data,
+  cols = c("size", "bm"),
+  lag = months(2),
+  by = "permno"
+)
+
+# Window lag: each row gets the most recent value from 2 to 4 months earlier
+add_lagged_columns(
+  data,
+  cols = "size",
+  lag = months(2),
+  max_lag = months(4),
+  by = "permno"
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/add_lagged_columns.R
+
+## compute_rolling_value
+
+Compute a Rolling Value by Period
+
+Applies an arbitrary summary function over rolling time-period windows.
+Each window spans periods units of period (e.g., 12 months). Before
+calling .f, rows with any missing values are dropped from the window;
+if fewer than min_obs rows remain, the result is NA_real_ instead.
+
+Usage:
+```r
+compute_rolling_value(
+  data,
+  .f,
+  period = "month",
+  periods = 12,
+  min_obs = periods,
+  data_options = NULL
+)
+```
+
+Arguments:
+- `data`: A data frame with a date column of class Date, named according
+to data_options$date (default "date").
+- `.f`: A function applied to each window. Receives a data-frame slice
+(complete cases only) and must return a single scalar value.
+- `period`: A string specifying the period for rolling windows
+(e.g., "month", "quarter", "year").
+- `periods`: Number of periods to include in the rolling window.
+- `min_obs`: Minimum number of non-missing rows required per window.
+Defaults to periods.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The date element is
+used to specify the date column. Uses {data_options()} default if NULL:
+"date" = "date".
+
+Value: A numeric vector aligned with the rows of data.
+
+Examples:
+```r
+library(dplyr)
+
+# Rolling standard deviation
+set.seed(42)
+df <- tibble(
+  date = seq.Date(
+    from = as.Date("2020-01-01"),
+    by = "month",
+    length.out = 24
+  ),
+  value = rnorm(24)
+)
+
+df |>
+  mutate(
+    rolling_sd = compute_rolling_value(
+      pick(everything()),
+      .f = ~ sd(.x$value, na.rm = TRUE),
+      period = "month",
+      periods = 4,
+      min_obs = 2
+    )
+  )
+
+# Rolling last residual from a regression
+set.seed(42)
+df_reg <- tibble(
+  date = seq.Date(
+    from = as.Date("2020-01-01"),
+    by = "month",
+    length.out = 60
+  ),
+  ret_excess = rnorm(60, 0, 0.05),
+  mkt_excess = rnorm(60, 0, 0.04),
+  smb = rnorm(60, 0, 0.03),
+  hml = rnorm(60, 0, 0.03)
+)
+
+df_reg |>
+  mutate(
+    residual = compute_rolling_value(
+      pick(everything()),
+      .f = \(x) {
+        last(lm(ret_excess ~ mkt_excess + smb + hml, data = x)$residuals)
+      },
+      period = "month",
+      periods = 24,
+      min_obs = 12
+    )
+  )
+
+# Rolling cumulative-return-to-SD ratio
+set.seed(42)
+df_resid <- tibble(
+  date = seq.Date(
+    from = as.Date("2020-01-01"),
+    by = "month",
+    length.out = 24
+  ),
+  int_roll_residual = rnorm(24, 0, 0.02)
+)
+
+df_resid |>
+  mutate(
+    return_to_sd = compute_rolling_value(
+      pick(everything()),
+      .f = ~ (prod(1 + .x$int_roll_residual) - 1) / sd(.x$int_roll_residual),
+      period = "month",
+      periods = 12,
+      min_obs = 12
+    )
+  )
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_rolling_value.R
+
+## join_lagged_values
+
+Join Lagged Variable Values over a Date Range
+
+Joins lagged values of selected variables from one dataset (new_data)
+into another (original_data), based on date ranges defined by min_lag
+and max_lag. Unlike {add_lagged_columns()}, this function supports
+joining across data frames with different date grids (e.g., monthly source
+data into quarterly target data).
+
+Usage:
+```r
+join_lagged_values(
+  original_data,
+  new_data,
+  id_keys,
+  min_lag,
+  max_lag,
+  ff_adjustment = FALSE,
+  data_options = NULL
+)
+```
+
+Arguments:
+- `original_data`: A data frame containing the target panel data.
+- `new_data`: A data frame containing the source variables to lag and
+merge. All columns besides id_keys and the date column will be lagged
+and joined.
+- `id_keys`: A character vector specifying the identifier column(s).
+- `min_lag`: A lubridate::Period specifying the lower lag bound
+(inclusive).
+- `max_lag`: A lubridate::Period specifying the upper lag bound
+(inclusive).
+- `ff_adjustment`: Logical; if TRUE, keeps only the last observation
+per identifier and year before lagging (Fama-French convention). Defaults
+to FALSE.
+- `data_options`: A list of class tidyfinance_data_options (created via
+{data_options()}) specifying column name mappings. The date element is
+used to identify the date column. Uses {data_options()} default if
+NULL: "date" = "date".
+
+Value: A data frame with all columns from original_data plus the
+lagged columns from new_data (keeping their original names).
+
+Examples:
+```r
+set.seed(42)
+library(dplyr)
+library(lubridate)
+
+df1 <- tibble(
+  id = rep(1:2, each = 6),
+  date = rep(seq(as.Date("2020-01-01"), by = "month", length.out = 6), 2)
+)
+
+df2 <- df1 |>
+  mutate(x = rnorm(n()))
+
+join_lagged_values(
+  original_data = df1,
+  new_data = df2,
+  id_keys = "id",
+  min_lag = months(1),
+  max_lag = months(3)
+)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/join_lagged_values.R
+
+## create_summary_statistics
+
+Create Summary Statistics for Specified Variables
+
+Computes a set of summary statistics for numeric and integer variables in a
+data frame. It allows users to select specific variables for
+summarization and can calculate statistics for the whole dataset or within
+groups specified by the by argument. Additional detail levels for quantiles
+can be included.
+
+Usage:
+```r
+create_summary_statistics(
+  data,
+  ...,
+  by = NULL,
+  detail = FALSE,
+  drop_na = FALSE
+)
+```
+
+Arguments:
+- `data`: A data frame containing the variables to be summarized.
+- `...`: Comma-separated list of unquoted variable names in the data frame
+to summarize. These variables must be either numeric, integer, or logical.
+- `by`: An optional unquoted variable name to group the data before
+summarizing. If NULL (the default), summary statistics are computed
+across all observations.
+- `detail`: A logical flag indicating whether to compute detailed summary
+statistics, including additional quantiles. Defaults to FALSE, which
+computes basic statistics (n, mean, sd, min, median, max). When TRUE,
+additional quantiles (1%, 5%, 10%, 25%, 75%, 90%, 95%, 99%) are computed.
+- `drop_na`: A logical flag indicating whether to drop missing values for
+each variable (default is FALSE).
+
+Value: A tibble with summary statistics for each selected variable. If by
+is specified, the output includes the grouping variable as well. Each row
+represents a variable (and a group if by is used), and each column
+contains the computed statistics.
+
+Examples:
+```r
+data <- data.frame(
+  ret = c(0.01, -0.02, 0.03, NA, 0.005),
+  size = c(100, 200, 150, 300, 250),
+  group = c("A", "A", "B", "B", "A")
+)
+
+# Basic summary across all observations
+create_summary_statistics(data, ret, size)
+
+# Grouped summary
+create_summary_statistics(data, ret, size, by = group)
+
+# Detailed quantiles
+create_summary_statistics(data, ret, detail = TRUE)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/create_summary_statistics.R
+
+## get_available_huggingface_files
+
+List Parquet Files in a Hugging Face Dataset
+
+Query the Hugging Face Datasets API and return a tibble of files with a
+.parquet suffix. The function follows pagination links returned in the
+response Link header and returns path, size, and a resolved URL.
+
+Usage:
+```r
+get_available_huggingface_files(organization, dataset)
+```
+
+Arguments:
+- `organization`: Character(1). Hugging Face organization or user name.
+- `dataset`: Character(1). Dataset name under the organization.
+
+Value: A tibble with columns: path (character), size (numeric), and
+url (character).
+
+Examples:
+```r
+get_available_huggingface_files("voigtstefan", "sp500")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R
+
+## list_supported_datasets
+
+List All Supported Datasets
+
+Aggregates and returns a comprehensive tibble of all supported datasets
+from different domains. It includes various datasets across different
+frequencies (daily, weekly, monthly, quarterly, annual) and models
+(e.g., q5 factors, Fama-French 3 and 5 factors, macro predictors).
+
+list_supported_types() is a soft-deprecated alias for
+list_supported_datasets().
+
+Usage:
+```r
+list_supported_datasets(domain = NULL, as_vector = FALSE)
+
+list_supported_types(domain = NULL, as_vector = FALSE)
+```
+
+Arguments:
+- `domain`: A character vector to filter for domain-specific datasets
+(e.g., c("WRDS", "Fama-French")).
+- `as_vector`: Logical indicating whether datasets should be returned
+as a character vector instead of a data frame.
+
+Value: A tibble aggregating all supported datasets with columns:
+type (the type of dataset), dataset_name (a descriptive name or
+file name of the dataset), and domain (the domain to which the
+dataset belongs, e.g., "Global Q", "Fama-French", "Goyal-Welch").
+
+Examples:
+```r
+# List all supported datasets as a data frame
+list_supported_datasets()
+
+# Filter by domain
+list_supported_datasets(domain = "WRDS")
+
+# List supported datasets as a vector
+list_supported_datasets(as_vector = TRUE)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_datasets_ff
+
+List Supported Fama-French Datasets
+
+Returns a tibble with the supported Fama-French datasets, including
+their names and frequencies (daily, weekly, monthly). Each dataset type
+is associated with a specific Fama-French model (e.g., 3 factors, 5
+factors). Additionally, it annotates each dataset with the domain
+"Fama-French".
+
+Usage:
+```r
+list_supported_datasets_ff()
+```
+
+Value: A tibble with columns: type (the type of dataset),
+dataset_name (a descriptive name of the dataset), file_url (the
+path of the source ZIP relative to Kenneth French's data library), and
+domain (the domain to which the dataset belongs, always "Fama-French").
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_datasets_ff_legacy
+
+List Supported Legacy Fama-French Datasets
+
+Returns a tibble with the legacy names of initially supported
+Fama-French datasets, including their names and frequencies (daily,
+weekly, monthly). Each dataset type is associated with a specific Fama-French
+model (e.g., 3 factors, 5 factors). Additionally, it annotates each dataset
+with the domain "Fama-French". Not included in the exported
+list_supported_datasets() function.
+
+Usage:
+```r
+list_supported_datasets_ff_legacy()
+```
+
+Value: A tibble with columns: type (the type of dataset), dataset_name
+(a descriptive name of the dataset), file_url (the path of the source
+ZIP relative to Kenneth French's data library), and domain (the domain
+to which the dataset belongs, always "Fama-French").
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_datasets_macro_predictors
+
+List Supported Macro Predictor Datasets
+
+Returns a tibble with the supported macro predictor datasets
+provided by Goyal-Welch, including their frequencies (monthly, quarterly,
+annual). All datasets reference the same source file,
+"PredictorData2022.xlsx" for the year 2022. Additionally, it annotates
+each dataset with the domain "Goyal-Welch".
+
+Usage:
+```r
+list_supported_datasets_macro_predictors()
+```
+
+Value: A tibble with columns: type (the type of dataset),
+dataset_name (the file name of the dataset, which is the same for
+all types), and domain (the domain to which the dataset belongs,
+always "Goyal-Welch").
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_datasets_other
+
+List Supported Other Datasets
+
+Returns a tibble listing the supported other datasets and their
+corresponding dataset names.
+
+Usage:
+```r
+list_supported_datasets_other()
+```
+
+Value: A tibble with columns: type (the type of dataset), dataset_name
+(the name of the data source), and domain (the domain to which the
+dataset belongs).
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_datasets_pseudo
+
+List Supported Pseudo WRDS Datasets
+
+Returns a tibble with the supported pseudo WRDS datasets generated by
+download_data(domain = "pseudo", ...). Annotated with the domain
+"pseudo".
+
+Usage:
+```r
+list_supported_datasets_pseudo()
+```
+
+Value: A tibble with columns: type, dataset_name, and domain.
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_datasets_wrds
+
+List Supported WRDS Datasets
+
+Returns a tibble with the supported datasets provided via WRDS.
+Additionally, it annotates each dataset with the domain "WRDS".
+
+Usage:
+```r
+list_supported_datasets_wrds()
+```
+
+Value: A tibble with columns: type (the type of dataset),
+dataset_name (the file name of the dataset), and domain (the
+domain to which the dataset belongs, always "WRDS").
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+
+## list_supported_indexes
+
+List Supported Indexes
+
+Returns a tibble containing information about supported financial indexes.
+Each index is associated with a URL that points to a CSV file containing the
+holdings of the index. Additionally, each index has a corresponding skip
+value, which indicates the number of lines to skip when reading the CSV file.
+
+Usage:
+```r
+list_supported_indexes()
+```
+
+Value: A tibble with three columns:
+\describe{
+\item{index}{The name of the financial index (e.g., "DAX", "S&P 500").}
+\item{url}{The URL to the CSV file containing the holdings data for the
+index.}
+\item{skip}{The number of lines to skip when reading the CSV file.}
+}
+
+Examples:
+```r
+supported_indexes <- list_supported_indexes()
+print(supported_indexes)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_indexes.R
+
+## list_tidy_finance_chapters
+
+List Chapters of Tidy Finance
+
+Returns a character vector containing the names of the chapters available in
+the Tidy Finance resource. It provides a quick reference to the
+various topics covered.
+
+Usage:
+```r
+list_tidy_finance_chapters()
+```
+
+Value: A character vector where each element is the name of a chapter
+available in the Tidy Finance resource. These names correspond to specific
+chapters in Tidy Finance with R.
+
+Examples:
+```r
+list_tidy_finance_chapters()
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_tidy_finance_chapters.R
+
+## open_tidy_finance_website
+
+Open Tidy Finance Website or Specific Chapter in Browser
+
+Opens the main Tidy Finance website or a specific chapter within the site in
+the user's default web browser. If a chapter is specified, the function
+constructs the URL to access the chapter directly.
+
+Usage:
+```r
+open_tidy_finance_website(chapter = NULL)
+```
+
+Arguments:
+- `chapter`: An optional character string specifying the chapter to open.
+If NULL (the default), the function opens the main page of Tidy Finance
+with R. If a chapter name is provided (e.g., "beta-estimation"), the
+function opens the corresponding chapter's page (e.g.,
+"beta-estimation.html"). If the chapter name does not exist, then the
+function opens the main page.
+
+Value: Invisible NULL. The function is called for its side effect of
+opening a web page.
+
+Examples:
+```r
+open_tidy_finance_website()
+open_tidy_finance_website("beta-estimation")
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/open_tidy_finance_website.R
+
+## trim
+
+Trim a Numeric Vector
+
+Removes the values in a numeric vector that are beyond the specified
+quantiles, effectively trimming the distribution based on the cut
+parameter. This process reduces the vector's length by excluding extreme
+values from both tails of the distribution.
+
+Usage:
+```r
+trim(x, cut)
+```
+
+Arguments:
+- `x`: A numeric vector to be trimmed.
+- `cut`: The proportion of data to be trimmed from both ends of the
+distribution. For example, a cut of 0.05 will remove the lowest and
+highest 5% of the data. Must be in [0, 0.5].
+
+Value: A numeric vector with the extreme values removed.
+
+Examples:
+```r
+set.seed(123)
+data <- rnorm(100)
+trimmed_data <- trim(x = data, cut = 0.05)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/trim.R
+
+## validate_dates
+
+Validate and Coerce Date Range Arguments
+
+Checks that start_date and end_date are a valid pair, coerces them to
+Date, and handles the case where both are NULL. When both are NULL and
+use_default_range = TRUE, a default range spanning from two years ago to
+one year ago is applied and reported to the user.
+
+Usage:
+```r
+validate_dates(start_date, end_date, use_default_range = FALSE)
+```
+
+Arguments:
+- `start_date`: A scalar coercible to Date via as.Date(), or NULL.
+- `end_date`: A scalar coercible to Date via as.Date(), or NULL.
+- `use_default_range`: A logical scalar. If TRUE and both date arguments
+are NULL, a default range spanning from two years ago to one year ago is
+used instead of returning NULL. Defaults to FALSE.
+
+Value: A named list with elements start_date and end_date, both of
+class Date (or NULL when no dates are provided and
+use_default_range = FALSE).
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/validate.R
+
+## winsorize
+
+Winsorize a Numeric Vector
+
+Replaces the values in a numeric vector that are beyond the specified
+quantiles with the boundary values of those quantiles. This is done for both
+tails of the distribution based on the cut parameter.
+
+Usage:
+```r
+winsorize(x, cut)
+```
+
+Arguments:
+- `x`: A numeric vector to be winsorized.
+- `cut`: The proportion of data to be winsorized from both ends of the
+distribution. For example, a cut of 0.05 will winsorize the lowest and
+highest 5% of the data. Must be in [0, 0.5].
+
+Value: A numeric vector with the extreme values replaced by the
+corresponding quantile values.
+
+Examples:
+```r
+set.seed(123)
+data <- rnorm(100)
+winsorized_data <- winsorize(data, 0.05)
+```
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/winsorize.R
+
+## list_supported_datasets_q
+
+List Supported Global Q Datasets
+
+Returns a tibble with the supported Global Q datasets, including
+their names and frequencies (daily, weekly, weekly week-to-week, monthly,
+quarterly, annual). Each dataset type is associated with the Global Q
+model, specifically the q5 factors model for the year 2023. Additionally,
+it annotates each dataset with the domain "Global Q".
+
+Usage:
+```r
+list_supported_datasets_q()
+```
+
+Value: A tibble with columns: type (the type of dataset),
+dataset_name (the file name of the dataset), and domain (the
+domain to which the dataset belongs, always "Global Q").
+
+Source: https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R
+

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,92 @@
+# tidyfinance
+
+> Tidy Finance Helper Functions. Helper functions for empirical research in financial economics, addressing a variety of topics covered in Scheuch, Voigt, and Weiss (2023) <doi:10.1201/b23237>. The package is designed to provide shortcuts for issues extensively discussed in the book, facilitating easier application of its concepts. For more information and resources related to the book, visit <https://www.tidy-finance.org/r/index.html>.
+
+tidyfinance is an R package of helper functions for empirical research in financial economics, accompanying the book Tidy Finance with R (Scheuch, Voigt, and Weiss, 2023). Each link points to the function's annotated source on GitHub. For complete inline reference (signatures, arguments, return values, and runnable examples) see llms-full.txt in the same location.
+
+## Download functions
+
+- [download_data](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data.R): Download and Process Data Based on Domain and Dataset
+- [download_data_constituents](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_constituents.R): Download Constituent Data
+- [download_data_factors_ff](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_factors.R): Download and Process Fama-French Factor Data
+- [download_data_factors_q](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_factors.R): Download and Process Global Q Factor Data
+- [download_data_fred](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_fred.R): Download and Process Data from FRED
+- [download_data_huggingface](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R): Download data from a Hugging Face dataset
+- [download_data_macro_predictors](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_macro_predictors.R): Download and Process Macro Predictor Data
+- [download_data_osap](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_osap.R): Download and Process Open Source Asset Pricing Data
+- [download_data_risk_free](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_risk_free.R): Download Risk-Free Rate Data
+- [download_data_stock_prices](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_stock_prices.R): Download Stock Data
+- [download_factor_library_grid](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R): Download the Factor Library Grid from Hugging Face
+- [download_factor_library_ids](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R): Download factor library returns for a vector of portfolio IDs
+
+## WRDS functions
+
+- [disconnect_connection](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/disconnect_connection.R): Disconnect Database Connection
+- [download_data_wrds](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds.R): Download Data from WRDS
+- [download_data_wrds_ccm_links](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_ccm_links.R): Download CCM Links from WRDS
+- [download_data_wrds_compustat](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_compustat.R): Download Data from WRDS Compustat
+- [download_data_wrds_crsp](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_crsp.R): Download Data from WRDS CRSP
+- [download_data_wrds_fisd](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_fisd.R): Download Filtered FISD Data from WRDS
+- [download_data_wrds_trace_enhanced](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_wrds_trace_enhanced.R): Download Enhanced TRACE Data from WRDS
+- [get_wrds_connection](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/get_wrds_connection.R): Establish a Connection to the WRDS Database
+- [set_wrds_credentials](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/set_wrds_credentials.R): Set WRDS Credentials
+
+## Pseudo-data functions (no credentials required)
+
+- [download_data_pseudo_ccm_links](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_pseudo_ccm_links.R): Generate Pseudo CCM Links
+- [download_data_pseudo_compustat](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_pseudo_compustat.R): Generate Pseudo Compustat Data
+- [download_data_pseudo_crsp](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_pseudo_crsp.R): Generate Pseudo CRSP Data
+
+## Estimation functions
+
+- [estimate_betas](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/estimate_betas.R): Estimate Rolling Betas
+- [estimate_fama_macbeth](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/estimate_fama_macbeth.R): Estimate Fama-MacBeth Regressions
+- [estimate_model](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/estimate_model.R): Estimate a Linear Model
+
+## Portfolio sorting functions
+
+- [assign_portfolio](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/assign_portfolio.R): Assign Portfolios Based on Sorting Variable
+- [breakpoint_options](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/breakpoint_options.R): Create Breakpoint Options for Portfolio Sorting
+- [compute_breakpoints](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_breakpoints.R): Compute Breakpoints Based on Sorting Variable
+- [compute_long_short_returns](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_long_short_returns.R): Compute Long-Short Returns
+- [compute_portfolio_returns](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_portfolio_returns.R): Compute Portfolio Returns
+- [data_options](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/data_options.R): Create Data Options
+- [filter_options](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/filter_options.R): Create Filter Options
+- [filter_sorting_data](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/filter_sorting_data.R): Filter Sorting Data
+- [implement_portfolio_sort](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/implement_portfolio_sort.R): Implement Portfolio Sort
+- [portfolio_sort_options](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/portfolio_sort_options.R): Create Portfolio Sort Options
+
+## Rolling and lagging functions
+
+- [add_lagged_columns](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/add_lagged_columns.R): Add Lagged Columns via Join
+- [compute_rolling_value](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/compute_rolling_value.R): Compute a Rolling Value by Period
+- [join_lagged_values](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/join_lagged_values.R): Join Lagged Variable Values over a Date Range
+
+## Utility and helper functions
+
+- [create_summary_statistics](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/create_summary_statistics.R): Create Summary Statistics for Specified Variables
+- [get_available_huggingface_files](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/download_data_huggingface.R): List Parquet Files in a Hugging Face Dataset
+- [list_supported_datasets](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List All Supported Datasets
+- [list_supported_datasets_ff](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported Fama-French Datasets
+- [list_supported_datasets_ff_legacy](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported Legacy Fama-French Datasets
+- [list_supported_datasets_macro_predictors](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported Macro Predictor Datasets
+- [list_supported_datasets_other](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported Other Datasets
+- [list_supported_datasets_pseudo](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported Pseudo WRDS Datasets
+- [list_supported_datasets_wrds](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported WRDS Datasets
+- [list_supported_indexes](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_indexes.R): List Supported Indexes
+- [list_tidy_finance_chapters](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_tidy_finance_chapters.R): List Chapters of Tidy Finance
+- [open_tidy_finance_website](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/open_tidy_finance_website.R): Open Tidy Finance Website or Specific Chapter in Browser
+- [trim](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/trim.R): Trim a Numeric Vector
+- [validate_dates](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/validate.R): Validate and Coerce Date Range Arguments
+- [winsorize](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/winsorize.R): Winsorize a Numeric Vector
+
+## Other
+
+- [list_supported_datasets_q](https://github.com/tidy-finance/r-tidyfinance/blob/main/R/list_supported_datasets.R): List Supported Global Q Datasets
+
+## Optional
+
+- [Package overview](https://github.com/tidy-finance/r-tidyfinance): README, installation, and contribution guide
+- [Tidy Finance with R (book)](https://www.tidy-finance.org/r/): full methodology and chapter-by-chapter explanations
+- [llms-full.txt](llms-full.txt): full inline documentation for every exported function
+


### PR DESCRIPTION
## What

Prototype for making the `tidyfinance` API discoverable to LLM coding agents (Claude Code, Cursor, Copilot, etc.) following the [llms.txt convention](https://llmstxt.org).

Adds two generated text files plus a reproducible generator:

- **`llms.txt`** — a compact, grouped index of every exported function (one-line description + link to its annotated source), grouped by `@family`/`\concept` (Download, WRDS, Pseudo-data, Estimation, Portfolio sorting, Rolling/lagging, Utility).
- **`llms-full.txt`** — the full inline reference for all 56 exported functions: title, description, usage signature, arguments, return value, and runnable examples.
- **`data-raw/generate_llms_txt.R`** — base-R generator that parses `DESCRIPTION` and `man/*.Rd` and rewrites both files. Re-run with `Rscript data-raw/generate_llms_txt.R` whenever the docs change.

## Why

These files are standalone plain text — they do **not** require the pkgdown/Quarto homepage. The convention is to serve them at a site root (e.g. `https://www.tidy-finance.org/r/llms.txt`), but they work equally well from the repo root or shipped in the package. This is the lowest-effort, highest-leverage way to get LLMs to generate correct `tidyfinance` code, and a natural foundation for a later MCP server.

## Notes

- Both generated files are added to `.Rbuildignore` so they don't affect `R CMD check`.
- Dev version bumped `0.6.0.9002 → 0.6.0.9003`; `NEWS.md` updated.
- The committed `.txt` artifacts were bootstrapped for review; `generate_llms_txt.R` is the canonical source going forward.

## Possible follow-ups

- Wire the generator into CI / the website deploy so the files stay current.
- Decide on the canonical hosting location (website root vs. `inst/`).
- A thin `mcptools`-based MCP server scoped to credential-free functions (factors, FRED, pseudo-data, estimation) for agents that should *execute* rather than just read.

https://claude.ai/code/session_01KXYxoGrrdQSgBFMKG99USi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXYxoGrrdQSgBFMKG99USi)_