### PR TITLE
CRSP v1 end date check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.6.0.9003
+Version: 0.6.0.9004
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Improvements
 
+- `download_data_wrds_crsp()` now errors informatively when `version = "v1"`
+  is used with an `end_date` later than December 2024, reflecting the
+  discontinuation of the CRSP legacy version at the end of 2024.
+
 - Removed the "experimental" lifecycle badge from `assign_portfolio()`,
   `compute_breakpoints()`, `compute_rolling_value()`, `estimate_model()`,
   and `join_lagged_values()`, which are now considered stable.

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -116,6 +116,17 @@ download_data_wrds_crsp <- function(
   start_date <- dates$start_date
   end_date <- dates$end_date
 
+  if (version == "v1" && end_date > as.Date("2024-12-31")) {
+    cli::cli_abort(
+      c(
+        "{.arg end_date} must not be later than December 2024 for
+        {.arg version} = {.str v1}.",
+        "i" = "CRSP discontinued the legacy version at the end of 2024.",
+        "i" = "Use {.arg version} = {.str v2} for more recent data."
+      )
+    )
+  }
+
   con <- get_wrds_connection()
 
   if (dataset == "crsp_monthly") {

--- a/R/download_data_wrds_crsp.R
+++ b/R/download_data_wrds_crsp.R
@@ -119,8 +119,10 @@ download_data_wrds_crsp <- function(
   if (version == "v1" && end_date > as.Date("2024-12-31")) {
     cli::cli_abort(
       c(
-        "{.arg end_date} must not be later than December 2024 for
-        {.arg version} = {.str v1}.",
+        paste(
+          "{.arg end_date} must not be later than December 2024 for",
+          "{.arg version} = {.str v1}."
+        ),
         "i" = "CRSP discontinued the legacy version at the end of 2024.",
         "i" = "Use {.arg version} = {.str v2} for more recent data."
       )

--- a/tests/testthat/test-download_data_wrds_crps.R
+++ b/tests/testthat/test-download_data_wrds_crps.R
@@ -32,6 +32,28 @@ test_that("CRSP argument validation covers required inputs", {
     download_data_wrds_crsp("bad"),
     "Unsupported CRSP dataset"
   )
+
+  expect_error(
+    download_data_wrds_crsp(
+      "crsp_monthly",
+      end_date = "2025-01-01",
+      version = "v1"
+    ),
+    "end_date"
+  )
+})
+
+test_that("v1 end_date boundary: 2024-12-31 is allowed, 2025-01-01 is not", {
+  with_crsp_mocks({
+    expect_no_error(
+      download_data_wrds_crsp(
+        "crsp_monthly",
+        start_date = "2020-01-01",
+        end_date = "2024-12-31",
+        version = "v1"
+      )
+    )
+  })
 })
 
 test_that("deprecated type inputs are translated to dataset", {

--- a/tests/testthat/test-download_data_wrds_crps.R
+++ b/tests/testthat/test-download_data_wrds_crps.R
@@ -43,19 +43,6 @@ test_that("CRSP argument validation covers required inputs", {
   )
 })
 
-test_that("v1 end_date boundary: 2024-12-31 is allowed", {
-  with_crsp_mocks({
-    expect_no_error(
-      download_data_wrds_crsp(
-        "crsp_monthly",
-        start_date = "2020-01-01",
-        end_date = "2024-12-31",
-        version = "v1"
-      )
-    )
-  })
-})
-
 test_that("deprecated type inputs are translated to dataset", {
   local_mocked_bindings(
     is_legacy_type_wrds = function(dataset) identical(dataset, "wrds_bad"),
@@ -243,6 +230,19 @@ with_crsp_mocks <- function(code) {
 
   force(code)
 }
+
+test_that("v1 end_date boundary: 2024-12-31 is allowed", {
+  with_crsp_mocks({
+    expect_no_error(
+      download_data_wrds_crsp(
+        "crsp_monthly",
+        start_date = "2020-01-01",
+        end_date = "2024-12-31",
+        version = "v1"
+      )
+    )
+  })
+})
 
 test_that("monthly CRSP v1 is processed", {
   with_crsp_mocks({

--- a/tests/testthat/test-download_data_wrds_crps.R
+++ b/tests/testthat/test-download_data_wrds_crps.R
@@ -43,7 +43,7 @@ test_that("CRSP argument validation covers required inputs", {
   )
 })
 
-test_that("v1 end_date boundary: 2024-12-31 is allowed, 2025-01-01 is not", {
+test_that("v1 end_date boundary: 2024-12-31 is allowed", {
   with_crsp_mocks({
     expect_no_error(
       download_data_wrds_crsp(


### PR DESCRIPTION
The CRSP v1 ends in December 2024. This would be silently ignored in the old version. I suggest an error if `end_date` is past the v1 range.

A related question is how we want to handle `validate_dates()` in this regard. The check comes after the dates are validated, but "use_default_range = TRUE" is a non-helpful choice if users do not specify any dates. Additionally, if I only specify an `end_date` or `start_date`, why did we opt to replace both dates if one is missing?