### PR TITLE
Move pkgdown site to r.tidy-finance.org

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.6.0.9005
+Version: 0.6.0.9006
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),
@@ -20,7 +20,7 @@ Description: Helper functions for empirical research in financial
     and resources related to the book, visit
     <https://www.tidy-finance.org/r/index.html>.
 License: MIT + file LICENSE
-URL: https://package.tidy-finance.org/, https://www.tidy-finance.org/r/
+URL: https://r.tidy-finance.org/, https://www.tidy-finance.org/r/
 BugReports: https://github.com/tidy-finance/r-tidyfinance/issues
 Depends: 
     R (>= 4.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Improvements
 
+- The package website moved from `package.tidy-finance.org` to
+  `r.tidy-finance.org`.
+
 - `download_data()` now uses the human-readable domain names returned by
   `list_supported_datasets()` (e.g., `"Fama-French"`, `"Global Q"`,
   `"WRDS"`, `"Tidy Finance"`). The `"pseudo"` and `"tidyfinance"` domains

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://package.tidy-finance.org
+url: https://r.tidy-finance.org
 template:
   bootstrap: 5
   bootswatch: cosmo

--- a/man/tidyfinance-package.Rd
+++ b/man/tidyfinance-package.Rd
@@ -11,7 +11,7 @@ Helper functions for empirical research in financial economics, addressing a var
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://package.tidy-finance.org/}
+  \item \url{https://r.tidy-finance.org/}
   \item \url{https://www.tidy-finance.org/r/}
   \item Report bugs at \url{https://github.com/tidy-finance/r-tidyfinance/issues}
 }


### PR DESCRIPTION
Changes the pkgdown website domain from `package.tidy-finance.org` to `r.tidy-finance.org`.

## Changes
- `_pkgdown.yml`: updated `url:` (drives the canonical site URL and the `CNAME` written on deploy)
- `DESCRIPTION`: updated `URL:` field; bumped dev version `0.6.0.9005` → `0.6.0.9006`
- `man/tidyfinance-package.Rd`: updated generated link to match
- `NEWS.md`: added note about the move