### PR TITLE
Treat explicit n_portfolios_secondary = NULL as "all values"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.7.0.9000
+Version: 0.7.0.9001
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # tidyfinance (development version)
 
+## Bug fixes
+
+- `download_data_huggingface("factor_library", ...)` now treats an explicit
+  `n_portfolios_secondary = NULL` as "remove the filter and return all values"
+  (univariate and bivariate sorts alike), consistent with the documented
+  behavior for every other column. Previously an explicit `NULL` was coerced to
+  `NA`, restricting the result to univariate sorts.
+
 # tidyfinance 0.7.0
 
 ## Improvements

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -356,14 +356,22 @@ filter_factor_library_grid <- function(..., fill_all = FALSE) {
     ))
   }
 
+  # Capture the names the user actually supplied before filling defaults.
+  # `list(x = NULL)` keeps `x` in `names()`, so this distinguishes a column
+  # the user omitted from one they explicitly set to `NULL`.
+  user_supplied <- names(filters)
+
   if (!fill_all) {
     for (col in names(defaults)) {
-      if (!col %in% names(filters)) {
+      if (!col %in% user_supplied) {
         filters[col] <- list(defaults[[col]])
       }
     }
 
-    if (is.null(filters[["n_portfolios_secondary"]])) {
+    # Only default `n_portfolios_secondary` to NA when the user did not
+    # supply the argument at all. An explicit `NULL` removes the filter
+    # (returning all values), consistent with every other column.
+    if (!("n_portfolios_secondary" %in% user_supplied)) {
       sorting_methods <- filters[["sorting_method"]]
       if (!all(sorting_methods == "univariate")) {
         cli::cli_abort(c(

--- a/tests/testthat/test-download_data_huggingface.R
+++ b/tests/testthat/test-download_data_huggingface.R
@@ -315,6 +315,38 @@ test_that("fill_all = TRUE: only explicit filters applied", {
   expect_equal(ids, 1L)
 })
 
+test_that("explicit n_portfolios_secondary = NULL returns all values", {
+  # Row 1 is a univariate sort (NA secondary); row 2 is a bivariate sort
+  # with a non-NA secondary. Passing NULL should remove the filter and
+  # return both, rather than restricting to the NA (univariate) row.
+  grid <- tibble::tibble(
+    id = c(1L, 2L),
+    sorting_variable = c("sv_me", "sv_me"),
+    min_size_quantile = c(0.2, 0.2),
+    exclude_financials = c(FALSE, FALSE),
+    exclude_utilities = c(FALSE, FALSE),
+    exclude_negative_earnings = c(FALSE, FALSE),
+    sorting_variable_lag = c("6m", "6m"),
+    rebalancing = c("monthly", "monthly"),
+    n_portfolios_main = c(10L, 10L),
+    sorting_method = c("univariate", "univariate"),
+    n_portfolios_secondary = c(NA_real_, 5),
+    breakpoints_exchanges = c("NYSE", "NYSE"),
+    breakpoints_min_size_threshold = c(NA_real_, NA_real_),
+    weighting_scheme = c("VW", "VW")
+  )
+  testthat::local_mocked_bindings(
+    download_factor_library_grid = function() grid
+  )
+
+  ids <- filter_factor_library_grid(
+    sorting_variable = "me",
+    n_portfolios_secondary = NULL
+  )
+
+  expect_equal(ids, c(1L, 2L))
+})
+
 # ── download_factor_library_grid ─────────────────────
 
 test_that("pulls url from available files and reads parquet", {


### PR DESCRIPTION
## Summary

Fixes #285. `download_data_huggingface("factor_library", ...)` documents that passing `NULL` for any filter column removes that filter entirely and returns all values. This held for every column **except** `n_portfolios_secondary`, which was special-cased to be coerced to `NA_real_` — so an explicit `n_portfolios_secondary = NULL` restricted the result to univariate (NA) rows instead of removing the filter.

The guard in `filter_factor_library_grid()` keyed off the *value* being `NULL`, which is indistinguishable from the column being omitted (`list(x = NULL)` keeps `x` in `names()`).

## Changes

- **`R/download_data_huggingface.R`**: capture the user-supplied argument names *before* filling defaults, and key the `NA_real_` default off whether the user omitted the argument (`!("n_portfolios_secondary" %in% user_supplied)`) rather than off its value. An explicit `NULL` now survives to `purrr::compact()`, which drops it, so no filter is applied.
- **`tests/testthat/test-download_data_huggingface.R`**: added a test confirming `n_portfolios_secondary = NULL` returns both univariate (NA) and bivariate rows.
- **`NEWS.md`** / **`DESCRIPTION`**: bug-fix entry and version bump to `0.7.0.9001`.

This keeps the R side consistent with py-tidyfinance ([py-tidyfinance#58](https://github.com/tidy-finance/py-tidyfinance/pull/58)), where explicit `None` uniformly means "return all values".

## Testing

`testthat::test_file("tests/testthat/test-download_data_huggingface.R")` — all 31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)