### PR TITLE
Add `@examples` to exported `validate_dates()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.7.0.9001
+Version: 0.7.0.9002
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/R/validate.R
+++ b/R/validate.R
@@ -18,6 +18,16 @@
 #' @family utility functions
 #' @export
 #'
+#' @examples
+#' # Explicit range
+#' validate_dates("2020-01-01", "2020-12-31")
+#'
+#' # Both NULL with the default range applied (two years ago to one year ago)
+#' validate_dates(NULL, NULL, use_default_range = TRUE)
+#'
+#' # Both NULL returns NULL dates
+#' validate_dates(NULL, NULL)
+#'
 validate_dates <- function(start_date, end_date, use_default_range = FALSE) {
   if (is.null(start_date) || is.null(end_date)) {
     if (use_default_range) {

--- a/man/validate_dates.Rd
+++ b/man/validate_dates.Rd
@@ -26,6 +26,17 @@ Checks that \code{start_date} and \code{end_date} are a valid pair, coerces them
 \code{use_default_range = TRUE}, a default range spanning from two years ago to
 one year ago is applied and reported to the user.
 }
+\examples{
+# Explicit range
+validate_dates("2020-01-01", "2020-12-31")
+
+# Both NULL with the default range applied (two years ago to one year ago)
+validate_dates(NULL, NULL, use_default_range = TRUE)
+
+# Both NULL returns NULL dates
+validate_dates(NULL, NULL)
+
+}
 \seealso{
 Other utility functions: 
 \code{\link{create_summary_statistics}()},


### PR DESCRIPTION
## Summary

`validate_dates()` was the only exported function shipping without an `\examples{}` section in its `.Rd`. The [R Journal package guidelines](https://journal.r-project.org/R_package_guidelines.html) expect every user-facing function to be documented with runnable examples.

This PR adds an `@examples` block to the roxygen above `validate_dates()` in `R/validate.R`, covering the three behaviors:

- explicit date range,
- both `NULL` with `use_default_range = TRUE` (default two-years-ago to one-year-ago range), and
- both `NULL` returning `NULL` dates.

`man/validate_dates.Rd` is regenerated via `devtools::document()` and now ships an `\examples{}` section. All three examples were verified to run without error.

The development version is bumped `0.7.0.9001 → 0.7.0.9002`.

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)