### PR TITLE
Align OSAP download with beginning-of-month and scale returns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.7.0.9002
+Version: 0.7.0.9003
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # tidyfinance (development version)
 
+## Improvements
+
+- `download_data("Open Source Asset Pricing")` now aligns the `date` column to
+  the beginning of the month (the dataset previously returned end-of-month
+  dates), matching the convention used by the other download functions. All
+  predictor columns are monthly long-short returns expressed in percent and are
+  now divided by 100 to return plain numeric (decimal) returns.
+
 ## Bug fixes
 
 - `download_data_huggingface("factor_library", ...)` now treats an explicit

--- a/R/download_data_osap.R
+++ b/R/download_data_osap.R
@@ -3,8 +3,15 @@
 #' Downloads the data from
 #' [Open Source Asset Pricing](https://www.openassetpricing.com/data/)
 #' from Google Sheets using a specified sheet ID, processes the data
-#' by converting column names to snake_case, and optionally filters
-#' the data based on a provided date range.
+#' by converting column names to snake_case, aligning the date to the
+#' beginning of the month, scaling the percentage long-short returns to
+#' numeric values, and optionally filters the data based on a provided
+#' date range.
+#'
+#' The dataset contains monthly long-short returns of the predictor
+#' portfolios. Every column other than `date` is a return expressed in
+#' percent, so all of them are divided by 100 to convert them into plain
+#' numeric (decimal) returns.
 #'
 #' @param start_date Optional. A character string or Date object in
 #'   "YYYY-MM-DD" format specifying the start date for the data. If
@@ -17,8 +24,11 @@
 #'   `"1JyhcF5PRKHcputlioxlu5j5GyLo4JYyY"`.
 #'
 #' @returns A tibble containing the processed data. The column names
-#'   are converted to snake_case, and the data is filtered by the
-#'   specified date range if `start_date` and `end_date` are provided.
+#'   are converted to snake_case, the `date` column is aligned to the
+#'   beginning of the month, all predictor columns (long-short returns
+#'   in percent) are divided by 100 to obtain plain numeric (decimal)
+#'   returns, and the data is filtered by the specified date range if
+#'   `start_date` and `end_date` are provided.
 #'
 #' @family download functions
 #' @export
@@ -55,9 +65,14 @@ download_data_osap <- function(
   }
 
   processed_data <- raw_data |>
-    mutate(date = ymd(.data$date))
+    mutate(date = floor_date(ymd(.data$date), "month"))
 
   colnames(processed_data) <- to_snake_case(colnames(processed_data))
+
+  # All columns except the date are long-short returns in percent, so
+  # scale them to plain numeric (decimal) returns.
+  processed_data <- processed_data |>
+    mutate(across(-"date", \(x) x / 100))
 
   if (!is.null(start_date) && !is.null(end_date)) {
     processed_data <- processed_data |>

--- a/man/download_data_osap.Rd
+++ b/man/download_data_osap.Rd
@@ -25,15 +25,26 @@ from which to download the data. Default is
 }
 \value{
 A tibble containing the processed data. The column names
-are converted to snake_case, and the data is filtered by the
-specified date range if \code{start_date} and \code{end_date} are provided.
+are converted to snake_case, the \code{date} column is aligned to the
+beginning of the month, all predictor columns (long-short returns
+in percent) are divided by 100 to obtain plain numeric (decimal)
+returns, and the data is filtered by the specified date range if
+\code{start_date} and \code{end_date} are provided.
 }
 \description{
 Downloads the data from
 \href{https://www.openassetpricing.com/data/}{Open Source Asset Pricing}
 from Google Sheets using a specified sheet ID, processes the data
-by converting column names to snake_case, and optionally filters
-the data based on a provided date range.
+by converting column names to snake_case, aligning the date to the
+beginning of the month, scaling the percentage long-short returns to
+numeric values, and optionally filters the data based on a provided
+date range.
+}
+\details{
+The dataset contains monthly long-short returns of the predictor
+portfolios. Every column other than \code{date} is a return expressed in
+percent, so all of them are divided by 100 to convert them into plain
+numeric (decimal) returns.
 }
 \examples{
 \donttest{

--- a/tests/testthat/test-download_data_osap.R
+++ b/tests/testthat/test-download_data_osap.R
@@ -6,7 +6,7 @@ test_that("downloads and processes all rows", {
     handle_download_error = function(expr, fallback) expr(),
     read.csv = function(file, ...) {
       data.frame(
-        date = c("2020-01-01", "2020-02-01"),
+        date = c("2020-01-31", "2020-02-29"),
         LongName = c(1, 2),
         check.names = FALSE
       )
@@ -17,7 +17,10 @@ test_that("downloads and processes all rows", {
 
   expect_s3_class(result, "tbl_df")
   expect_equal(names(result), c("date", "long_name"))
+  # Dates are aligned to the beginning of the month.
   expect_equal(result$date, ymd(c("2020-01-01", "2020-02-01")))
+  # Percentage returns are scaled to numeric (decimal) values.
+  expect_equal(result$long_name, c(0.01, 0.02))
 })
 
 test_that("filters rows when both dates are supplied", {
@@ -31,7 +34,7 @@ test_that("filters rows when both dates are supplied", {
     handle_download_error = function(expr, fallback) expr(),
     read.csv = function(file, ...) {
       data.frame(
-        date = c("2020-01-01", "2020-02-01", "2020-03-01"),
+        date = c("2020-01-31", "2020-02-29", "2020-03-31"),
         value = c(1, 2, 3)
       )
     }
@@ -44,7 +47,7 @@ test_that("filters rows when both dates are supplied", {
 
   expect_equal(nrow(result), 1)
   expect_equal(result$date, ymd("2020-02-01"))
-  expect_equal(result$value, 2)
+  expect_equal(result$value, 0.02)
 })
 
 test_that("returns empty tibble after download failure", {


### PR DESCRIPTION
Ports [py-tidyfinance#59](https://github.com/tidy-finance/py-tidyfinance/pull/59) to the R package.

## Changes

- `download_data_osap()` (and `download_data("Open Source Asset Pricing")`) now aligns the `date` column to the **beginning of the month** via `floor_date(ymd(date), "month")`. The dataset previously returned end-of-month dates; this matches the convention used by the other download functions.
- All predictor columns are monthly long-short returns expressed in **percent** and are now divided by 100 to return plain numeric (decimal) returns.
- Updated roxygen docs (`@description`, `@returns`) and regenerated `man/download_data_osap.Rd`.
- Updated unit tests to use end-of-month input dates and assert beginning-of-month alignment plus scaled returns.
- Added a NEWS entry and bumped the development version to `0.7.0.9003`.

## Testing

All tests in `test-download_data_osap.R` pass (11 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)