### PR TITLE
Document adj_r_squared in estimate_fama_macbeth detail output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.8.0.9001
+Version: 0.8.0.9002
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@
 
 ## Bug fixes
 
+- The documentation of `estimate_fama_macbeth(detail = TRUE)` now lists the
+  `adj_r_squared` column, which the function has always returned in
+  `summary_statistics` alongside `r_squared` and `n_obs`.
 - `download_data_huggingface("factor_library", ...)` now treats an explicit
   `n_portfolios_secondary = NULL` as "remove the filter and return all values"
   (univariate and bivariate sorts alike), consistent with the documented

--- a/R/estimate_fama_macbeth.R
+++ b/R/estimate_fama_macbeth.R
@@ -27,8 +27,9 @@
 #'   summary statistics. If `FALSE` (default), the function returns only the
 #'   coefficient estimates. If `TRUE`, it returns a list with two elements:
 #'   `coefficients` (the usual estimates table) and `summary_statistics` (a
-#'   one-row tibble with the average cross-sectional R-squared and the average
-#'   number of observations per cross-section).
+#'   one-row tibble with the average cross-sectional R-squared, the average
+#'   cross-sectional adjusted R-squared, and the average number of
+#'   observations per cross-section).
 #'
 #' @returns If `detail = FALSE` (default), a tibble with columns
 #'   `factor`, `risk_premium`, `n` (number of time periods),
@@ -38,7 +39,8 @@
 #'   \describe{
 #'     \item{coefficients}{The same tibble described above.}
 #'     \item{summary_statistics}{A one-row tibble with `r_squared` (mean
-#'       cross-sectional R-squared) and `n_obs` (mean cross-sectional
+#'       cross-sectional R-squared), `adj_r_squared` (mean cross-sectional
+#'       adjusted R-squared), and `n_obs` (mean cross-sectional
 #'       observation count).}
 #'   }
 #'

--- a/man/estimate_fama_macbeth.Rd
+++ b/man/estimate_fama_macbeth.Rd
@@ -41,8 +41,9 @@ used to specify the date column. Uses \code{\link[=data_options]{data_options()}
 summary statistics. If \code{FALSE} (default), the function returns only the
 coefficient estimates. If \code{TRUE}, it returns a list with two elements:
 \code{coefficients} (the usual estimates table) and \code{summary_statistics} (a
-one-row tibble with the average cross-sectional R-squared and the average
-number of observations per cross-section).}
+one-row tibble with the average cross-sectional R-squared, the average
+cross-sectional adjusted R-squared, and the average number of
+observations per cross-section).}
 }
 \value{
 If \code{detail = FALSE} (default), a tibble with columns
@@ -53,7 +54,8 @@ If \code{detail = TRUE}, a named list with two elements:
 \describe{
 \item{coefficients}{The same tibble described above.}
 \item{summary_statistics}{A one-row tibble with \code{r_squared} (mean
-cross-sectional R-squared) and \code{n_obs} (mean cross-sectional
+cross-sectional R-squared), \code{adj_r_squared} (mean cross-sectional
+adjusted R-squared), and \code{n_obs} (mean cross-sectional
 observation count).}
 }
 }


### PR DESCRIPTION
## Summary

`estimate_fama_macbeth(detail = TRUE)` builds `summary_statistics` as `tibble(r_squared, adj_r_squared, n_obs)`, but both the `@param detail` and `@returns` roxygen blocks listed only `r_squared` and `n_obs`. This documents the `adj_r_squared` column that the function has always returned.

Surfaced while cross-checking r-tidyfinance against py-tidyfinance (which returns all three) during the Python polars rewrite.

## Changes

- `R/estimate_fama_macbeth.R` — mention `adj_r_squared` in the `@param detail` description and the `@returns` `\describe` block.
- `man/estimate_fama_macbeth.Rd` — corresponding regenerated text.
- `DESCRIPTION` — development version `0.8.0.9001` → `0.8.0.9002` (one bump for this PR, per the repo convention).
- `NEWS.md` — entry under Bug fixes.

Documentation only; no behavior change.

**Note:** R is not available in this environment, so the `.Rd` was hand-edited to match what roxygen2 would emit rather than produced by `devtools::document()`. Worth a quick `devtools::document()` run before merging to confirm there is no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLdvneQWiAprCUYAsdA6Ar

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLdvneQWiAprCUYAsdA6Ar)_