### PR TITLE
Sort cross-sections chronologically in estimate_fama_macbeth()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.8.0.9002
+Version: 0.8.0.9003
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,18 @@
   are read from the St. Louis Fed vintage archive ZIPs), enabling leak-free
   point-in-time analysis.
 
+## Bug fixes
+
+- `estimate_fama_macbeth()` now orders the cross-sections chronologically
+  before aggregating them over time. Newey-West standard errors depend on the
+  order of the time series, so the same data in a different row order
+  previously returned different standard errors and t-statistics while the
+  risk premia were unchanged. Results for chronologically sorted input are
+  unaffected (#302).
+- The documentation of `estimate_fama_macbeth(detail = TRUE)` now lists the
+  `adj_r_squared` column, which the function has always returned in
+  `summary_statistics` alongside `r_squared` and `n_obs`.
+
 # tidyfinance 0.8.0
   
 ## New features
@@ -61,9 +73,6 @@
 
 ## Bug fixes
 
-- The documentation of `estimate_fama_macbeth(detail = TRUE)` now lists the
-  `adj_r_squared` column, which the function has always returned in
-  `summary_statistics` alongside `r_squared` and `n_obs`.
 - `download_data_huggingface("factor_library", ...)` now treats an explicit
   `n_portfolios_secondary = NULL` as "remove the filter and return all values"
   (univariate and bivariate sorts alike), consistent with the documented

--- a/R/estimate_fama_macbeth.R
+++ b/R/estimate_fama_macbeth.R
@@ -118,8 +118,11 @@ estimate_fama_macbeth <- function(
     cli::cli_abort("The data must contain a {data_options$date} column.")
   }
 
+  # Newey-West standard errors depend on the order of the time series, so the
+  # cross-sections are sorted chronologically before they are aggregated.
   cross_sections <- data |>
     tidyr::nest(data = -all_of(data_options$date)) |>
+    arrange(.data[[data_options$date]]) |>
     mutate(
       row_check = purrr::map_lgl(
         data,

--- a/tests/testthat/test-estimate_fama_macbeth.R
+++ b/tests/testthat/test-estimate_fama_macbeth.R
@@ -365,3 +365,65 @@ test_that("estimate_fama_macbeth detail works with different vcov options", {
     )
   )
 })
+
+test_that("estimate_fama_macbeth results do not depend on input row order", {
+  set.seed(1234)
+  data <- tibble(
+    date = rep(
+      seq.Date(
+        from = as.Date("2020-01-01"),
+        to = as.Date("2020-12-01"),
+        by = "month"
+      ),
+      each = 50
+    ),
+    permno = rep(1:50, times = 12),
+    ret_excess = rnorm(600, 0, 0.1),
+    beta = rnorm(600, 1, 0.2),
+    bm = rnorm(600, 0.5, 0.1),
+    log_mktcap = rnorm(600, 10, 1)
+  )
+  model <- "ret_excess ~ beta + bm + log_mktcap"
+
+  sorted <- estimate_fama_macbeth(data, model, detail = TRUE)
+
+  set.seed(42)
+  shuffled <- estimate_fama_macbeth(data[sample(nrow(data)), ], model,
+    detail = TRUE
+  )
+  reversed <- estimate_fama_macbeth(data[rev(seq_len(nrow(data))), ], model,
+    detail = TRUE
+  )
+
+  expect_equal(shuffled, sorted)
+  expect_equal(reversed, sorted)
+})
+
+test_that("estimate_fama_macbeth sorts by a renamed date column", {
+  set.seed(1234)
+  data <- tibble(
+    month = rep(
+      seq.Date(
+        from = as.Date("2020-01-01"),
+        to = as.Date("2020-12-01"),
+        by = "month"
+      ),
+      each = 50
+    ),
+    permno = rep(1:50, times = 12),
+    ret_excess = rnorm(600, 0, 0.1),
+    beta = rnorm(600, 1, 0.2),
+    bm = rnorm(600, 0.5, 0.1)
+  )
+  model <- "ret_excess ~ beta + bm"
+  options <- data_options(date = "month")
+
+  sorted <- estimate_fama_macbeth(data, model, data_options = options)
+
+  set.seed(42)
+  shuffled <- estimate_fama_macbeth(data[sample(nrow(data)), ], model,
+    data_options = options
+  )
+
+  expect_equal(shuffled, sorted)
+})


### PR DESCRIPTION
Fixes #302.

> [!NOTE]
> Stacked on #301 (`claude/py-tidyfinance-polars-rewrite-2ecrb9`), so the diff shown here is only the #302 fix. GitHub will retarget this to `main` when #301 merges.

## The problem

`estimate_fama_macbeth()` nested the cross-sections in order of first appearance of each date in the input — `tidyr::nest(data = -date)` preserves row order, and nothing sorted by date before `sandwich::NeweyWest()` was applied. HAC standard errors are order-dependent, so the same panel in a different row order returned different standard errors and t-statistics. The risk premia were unaffected (a mean is order-invariant), which made it easy to miss.

Running the reporter's example against the released 0.8.0:

| build | factor | risk_premium | standard_error | t_statistic |
|---|---|---|---|---|
| date-sorted input | `bm` | 0.0712 | 0.0132 | **5.39** |
| shuffled input | `bm` | 0.0712 | 0.0263 | **2.71** |

## The fix

Sort the cross-sections chronologically before they are aggregated:

```r
cross_sections <- data |>
  tidyr::nest(data = -all_of(data_options$date)) |>
  arrange(.data[[data_options$date]]) |>
```

The issue suggested sorting the input panel before nesting. Sorting after nesting is equivalent and cheaper: `arrange()` is a stable sort, so sorting the panel by date leaves within-date row order exactly as nesting would, and row order within a cross-section does not enter the OLS fit, the R-squared, or the observation count. This sorts `T` rows instead of `N x T`.

`arrange` needs no import change — the package already does `@import dplyr`.

## Verification

- The reporter's example reproduces exactly on installed 0.8.0 and is gone on this branch; shuffled input now returns the date-sorted numbers, so **results for already-sorted input are unchanged**.
- `estimate_fama_macbeth()` is the only HAC user in the package — `sandwich::NeweyWest` appears nowhere else, so nothing similar needs the same fix.
- The `tidyfinance` vignette's Fama-MacBeth numbers are unchanged: its panel is ordered permno-first, but the first permno spans the sample, so dates already first-appeared chronologically. No article rebuild needed.
- `roxygen2::roxygenise()` (7.3.3, the pinned version) produces no changes.

## Tests

Two regression tests in `tests/testthat/test-estimate_fama_macbeth.R`:

- shuffled and reversed input match sorted input, with `detail = TRUE` so the summary statistics are covered too;
- the same for a renamed date column via `data_options(date = "month")`, covering the mapped-column path.

Both fail without the fix. The offline suite passes (24 test files, no failures).

## Note for review

This also moves the `adj_r_squared` NEWS entry from #301 out of the released `# tidyfinance 0.8.0` section into `# tidyfinance (development version)`. It was added after the 0.8.0 release commit, so it was describing an unreleased change under a shipped heading. Happy to drop that hunk if you would rather keep #301's entry where it is.

Development version bumped `0.8.0.9002` -> `0.8.0.9003`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
