### PR TITLE
Fix Yahoo Finance date handling: exchange time zone and inclusive range

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.8.0.9003
+Version: 0.8.0.9004
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,11 @@
 - The documentation of `estimate_fama_macbeth(detail = TRUE)` now lists the
   `adj_r_squared` column, which the function has always returned in
   `summary_statistics` alongside `r_squared` and `n_obs`.
+- `download_data_stock_prices()` now derives dates from the exchange time zone
+  reported by Yahoo Finance instead of converting the timestamps in UTC.
+  Timestamps refer to the market open in local time, so for exchanges ahead of
+  UTC (e.g. `"^AXJO"`, `"^NZ50"`) every observation was previously dated one
+  calendar day too early and could fall on a weekend.
 
 # tidyfinance 0.8.0
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,12 @@
   Timestamps refer to the market open in local time, so for exchanges ahead of
   UTC (e.g. `"^AXJO"`, `"^NZ50"`) every observation was previously dated one
   calendar day too early and could fall on a weekend.
+- `download_data_stock_prices()` now returns a range that is inclusive of both
+  `start_date` and `end_date` for every exchange, matching the other
+  `download_data_*()` functions. The range was previously delegated to Yahoo
+  Finance's `period1` / `period2`, which are resolved in the exchange's local
+  time zone, so `end_date` was excluded for markets at or behind UTC but
+  included for markets ahead of it.
 
 # tidyfinance 0.8.0
   

--- a/R/download_data_stock_prices.R
+++ b/R/download_data_stock_prices.R
@@ -86,12 +86,25 @@ download_data_stock_prices <- function(
       indicators <- raw_data[[1]]$indicators$adjclose
       indicators <- replace_null_with_na(indicators)
 
+      # Daily timestamps refer to the market open in the exchange's local time
+      # zone, so the dates must be derived in that zone. Converting in UTC
+      # shifts markets ahead of UTC (e.g. Australia, New Zealand) to the
+      # previous calendar day.
+      exchange_timezone <- raw_data[[1]]$meta$exchangeTimezoneName
+      if (is.null(exchange_timezone) || !nzchar(exchange_timezone)) {
+        exchange_timezone <- "UTC"
+      }
+
       processed_data_symbol <- tibble(
         "symbol" = symbols[j],
-        "date" = as.Date(as.POSIXct(
-          as.numeric(raw_data[[1]]$timestamp),
-          origin = "1970-01-01"
-        )),
+        "date" = as.Date(
+          as.POSIXct(
+            as.numeric(raw_data[[1]]$timestamp),
+            origin = "1970-01-01",
+            tz = "UTC"
+          ),
+          tz = exchange_timezone
+        ),
         "volume" = as.numeric(unlist(ohlcv$volume)),
         "open" = as.numeric(unlist(ohlcv$open)),
         "low" = as.numeric(unlist(ohlcv$low)),

--- a/R/download_data_stock_prices.R
+++ b/R/download_data_stock_prices.R
@@ -12,6 +12,10 @@
 #'   format specifying the end date for the data. If not provided, a one-year
 #'   subset of the dataset is returned (see [validate_dates()]).
 #'
+#' @details Dates are the trading days in the exchange's local time zone, as
+#'   reported by Yahoo Finance, and the range is inclusive of both
+#'   `start_date` and `end_date`.
+#'
 #' @returns A tibble containing the downloaded stock data with columns: symbol,
 #'   date, volume, open, low, high, close, and adjusted_close.
 #'
@@ -41,8 +45,15 @@ download_data_stock_prices <- function(
   start_date <- dates$start_date
   end_date <- dates$end_date
 
-  start_timestamp <- as.integer(as.POSIXct(start_date, tz = "UTC"))
-  end_timestamp <- as.integer(as.POSIXct(end_date, tz = "UTC"))
+  # Yahoo Finance resolves `period1` and `period2` against the exchange's local
+  # time zone, so a window expressed in UTC covers a different set of trading
+  # days for each market. Request a buffer around the range and filter on the
+  # converted dates below, which makes both bounds inclusive everywhere.
+  request_buffer <- 2
+  start_timestamp <- as.integer(
+    as.POSIXct(start_date - request_buffer, tz = "UTC")
+  )
+  end_timestamp <- as.integer(as.POSIXct(end_date + request_buffer, tz = "UTC"))
 
   processed_data <- list()
 
@@ -113,7 +124,8 @@ download_data_stock_prices <- function(
         "adjusted_close" = as.numeric(unlist(indicators))
       )
 
-      processed_data[[j]] <- processed_data_symbol
+      processed_data[[j]] <- processed_data_symbol |>
+        filter(between(.data$date, start_date, end_date))
     } else {
       error_message <- # nolint: object_usage_linter.
         httr2::resp_body_json(response)$chart$error

--- a/man/download_data_stock_prices.Rd
+++ b/man/download_data_stock_prices.Rd
@@ -26,6 +26,11 @@ date, volume, open, low, high, close, and adjusted_close.
 Downloads historical stock data from Yahoo Finance for given symbols and date
 range.
 }
+\details{
+Dates are the trading days in the exchange's local time zone, as
+reported by Yahoo Finance, and the range is inclusive of both
+\code{start_date} and \code{end_date}.
+}
 \examples{
 \donttest{
   download_data_stock_prices(c("AAPL", "MSFT"))

--- a/tests/testthat/test-download_data_stock_prices.R
+++ b/tests/testthat/test-download_data_stock_prices.R
@@ -181,3 +181,83 @@ test_that("dates use the exchange time zone reported by Yahoo Finance", {
     as.Date("2020-03-15")
   )
 })
+
+test_that("both range bounds are inclusive and the request is buffered", {
+  start_date <- as.Date("2020-03-02")
+  end_date <- as.Date("2020-03-06")
+
+  # Yahoo is asked for a buffered window, so it may return bars outside the
+  # requested range; those must be dropped.
+  returned_dates <- seq(
+    as.Date("2020-03-01"),
+    as.Date("2020-03-07"),
+    by = "day"
+  )
+  timestamps <- as.integer(as.POSIXct(returned_dates, tz = "UTC"))
+  n <- length(returned_dates)
+
+  captured <- new.env()
+
+  body <- list(
+    chart = list(
+      result = list(
+        list(
+          meta = list(exchangeTimezoneName = "UTC"),
+          timestamp = timestamps,
+          indicators = list(
+            quote = list(
+              list(
+                volume = as.list(seq_len(n)),
+                open = as.list(seq_len(n)),
+                low = as.list(seq_len(n)),
+                high = as.list(seq_len(n)),
+                close = as.list(seq_len(n))
+              )
+            ),
+            adjclose = list(
+              list(adjclose = as.list(seq_len(n)))
+            )
+          )
+        )
+      )
+    )
+  )
+
+  testthat::local_mocked_bindings(
+    validate_dates = function(start_date, end_date, use_default_range) {
+      list(start_date = as.Date("2020-03-02"), end_date = as.Date("2020-03-06"))
+    }
+  )
+  testthat::local_mocked_bindings(
+    request = function(url) list(url = url),
+    req_error = function(req, is_error) req,
+    req_perform = function(req) {
+      captured$url <- req$url
+      list(status_code = 200)
+    },
+    resp_body_json = function(response) body,
+    .package = "httr2"
+  )
+  testthat::local_mocked_bindings(
+    cli_progress_bar = function(...) invisible(NULL),
+    cli_progress_update = function(...) invisible(NULL),
+    .package = "cli"
+  )
+
+  out <- download_data_stock_prices("AAPL", start_date, end_date)
+
+  # Both bounds are inclusive and nothing outside the range survives.
+  expect_equal(out$date, seq(start_date, end_date, by = "day"))
+
+  # The request itself reaches two days beyond each bound.
+  expect_match(
+    captured$url,
+    paste0("period1=", as.integer(as.POSIXct(start_date - 2, tz = "UTC"))),
+    fixed = TRUE
+  )
+  expect_match(
+    captured$url,
+    paste0("period2=", as.integer(as.POSIXct(end_date + 2, tz = "UTC"))),
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-download_data_stock_prices.R
+++ b/tests/testthat/test-download_data_stock_prices.R
@@ -16,6 +16,7 @@ test_that("downloads data, replaces NULL, and warns on failures", {
     chart = list(
       result = list(
         list(
+          meta = list(exchangeTimezoneName = "UTC"),
           timestamp = c(1577836800, 1577923200),
           indicators = list(
             quote = list(
@@ -105,4 +106,78 @@ test_that("downloads data, replaces NULL, and warns on failures", {
   expect_equal(out$high, c(12, 13))
   expect_equal(out$close, c(11, 12))
   expect_equal(out$adjusted_close, c(11, NA))
+})
+
+test_that("dates use the exchange time zone reported by Yahoo Finance", {
+  # 1584313200 is 2020-03-16 10:00 in Australia/Sydney, i.e. the ASX open on
+  # the day of the COVID crash, but 2020-03-15 (a Sunday) in UTC.
+  make_body <- function(timezone) {
+    list(
+      chart = list(
+        result = list(
+          list(
+            meta = list(exchangeTimezoneName = timezone),
+            timestamp = 1584313200,
+            indicators = list(
+              quote = list(
+                list(
+                  volume = list(100),
+                  open = list(10),
+                  low = list(9),
+                  high = list(12),
+                  close = list(11)
+                )
+              ),
+              adjclose = list(
+                list(adjclose = list(11))
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  download_with_timezone <- function(timezone) {
+    testthat::local_mocked_bindings(
+      validate_dates = function(start_date, end_date, use_default_range) {
+        list(
+          start_date = as.Date("2020-03-01"),
+          end_date = as.Date("2020-03-31")
+        )
+      }
+    )
+    testthat::local_mocked_bindings(
+      request = function(url) list(url = url),
+      req_error = function(req, is_error) req,
+      req_perform = function(req) list(status_code = 200),
+      resp_body_json = function(response) make_body(timezone),
+      .package = "httr2"
+    )
+    testthat::local_mocked_bindings(
+      cli_progress_bar = function(...) invisible(NULL),
+      cli_progress_update = function(...) invisible(NULL),
+      .package = "cli"
+    )
+    download_data_stock_prices("^AXJO", "2020-03-01", "2020-03-31")
+  }
+
+  expect_equal(
+    download_with_timezone("Australia/Sydney")$date,
+    as.Date("2020-03-16")
+  )
+  expect_equal(
+    download_with_timezone("Pacific/Auckland")$date,
+    as.Date("2020-03-16")
+  )
+  # Markets at or behind UTC are unaffected by the fix.
+  expect_equal(
+    download_with_timezone("America/New_York")$date,
+    as.Date("2020-03-15")
+  )
+  # Missing time zone metadata falls back to UTC, i.e. the previous behavior.
+  expect_equal(
+    download_with_timezone(NULL)$date,
+    as.Date("2020-03-15")
+  )
 })


### PR DESCRIPTION
## Problem

A user comparing `download_data_stock_prices()` against an independent Python pipeline found that `^NZ50` and `^AXJO` trading days were dated one calendar day earlier in R, with identical prices. Around 145 NZ50 observations for 2018–2020 fell on Saturdays or Sundays, and the ASX crash of Monday 2020-03-16 was dated Sunday 2020-03-15. All other markets agreed.

Both issues below come from the same root cause: Yahoo Finance works in the **exchange's local time zone**, while this function worked in UTC.

## 1. Dates were derived in UTC

Yahoo's daily timestamps mark the **market open in the exchange's local time zone**. The dates were derived with `as.Date(as.POSIXct(timestamp, origin = "1970-01-01"))`, and `as.Date.POSIXct()` defaults to `tz = "UTC"`. For exchanges far enough ahead of UTC, the open still falls on the previous UTC day:

| Exchange | Open | In UTC |
|---|---|---|
| `^AXJO` Sydney | 10:00 AEDT | 23:00 **previous day** ❌ |
| `^NZ50` Auckland | 10:00 NZDT | 21:00 **previous day** ❌ |
| `^N225` Tokyo | 09:00 JST | 00:00 same day ✅ |
| `AAPL` New York | 09:30 ET | 14:30 same day ✅ |

This matches the reported pattern exactly — Tokyo and everything west of it is unaffected. Confirmed on the raw JSON: the ASX crash close of 5002.0 carries timestamp `1584313200` = Mon 2020-03-16 10:00 AEDT, which the old code dated to a Sunday.

**Fix:** use `meta$exchangeTimezoneName` from the response as the conversion zone, falling back to `"UTC"` when absent. `as.POSIXct()` is also pinned to `tz = "UTC"` so the epoch conversion no longer depends on the machine's locale.

## 2. `end_date` was inclusive for some markets and exclusive for others

The range was delegated entirely to Yahoo's `period1` / `period2`, which are also resolved in exchange-local time. A window expressed as UTC midnight therefore covered a different set of trading days per market — `end_date` was excluded for exchanges at or behind UTC but included for those ahead of it. A single-day request for a market ahead of UTC could not address its own trading day at all.

**Fix:** request a two-day buffer around the range and filter the converted dates with `between()`, making both bounds inclusive everywhere. This matches every other `download_data_*()` function in the package, all of which filter with `between(date, start_date, end_date)`.

## Verification

Weekend bars over the reporter's exact window, before and after:

```
^NZ50  n= 755 | weekend bars: after fix=  0, before fix (UTC)=145
^AXJO  n= 761 | weekend bars: after fix=  0, before fix (UTC)=147
```

145 for NZ50 reproduces the reported count exactly.

Boundary behavior across time zones for `2020-03-02 .. 2020-03-20`, live:

```
^AXJO   n=15  first=2020-03-02  last=2020-03-20
^NZ50   n=15  first=2020-03-02  last=2020-03-20
AAPL    n=15  first=2020-03-02  last=2020-03-20
^GDAXI  n=15  first=2020-03-02  last=2020-03-20
^N225   n=14  first=2020-03-02  last=2020-03-19
```

`^N225` ends a day earlier because 2020-03-20 is Vernal Equinox Day, a Tokyo market holiday — verified as genuinely absent from the response, not a boundary artifact.

Edge cases checked live: a single-day range on `^AXJO` now returns the 2020-03-16 crash bar (previously unreachable), a weekend-only range returns zero rows, and the default range path is unaffected.

New tests cover Sydney, Auckland, New York, the missing-metadata fallback, inclusive bounds, and the buffered request window.

## Notes

- `man/download_data_stock_prices.Rd` is regenerated; the documented behavior now states that dates are exchange-local and the range is inclusive.
- One behavior change worth flagging: with `end_date` now inclusive, requesting `end_date = Sys.Date()` includes the current, still-forming daily bar. The default range from `validate_dates()` ends a year back, so the default path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
