### PR TITLE
Read the id-range layout of the factor library

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidyfinance
 Title: Tidy Finance Helper Functions
-Version: 0.8.0.9004
+Version: 0.8.0.9005
 Authors@R: c(
     person("Christoph", "Scheuch", , "christoph@tidy-intelligence.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0004-0423-6819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # tidyfinance (development version)
 
+## Breaking changes
+
+- `download_factor_library_ids()` and
+  `download_data("Tidy Finance", "factor_library")` read the new layout of the
+  factor library on Hugging Face, where the returns hold only `id`, `date`, and
+  `ret` in files of 1,000 consecutive IDs named after their range. Only the
+  files that hold the requested IDs are downloaded, and the file listing of the
+  dataset is no longer queried. The result no longer has a `ret_type` column;
+  the weighting scheme is in the `weighting_scheme` column of the grid. Earlier
+  versions of the package cannot read the new layout.
+- The factor library now builds on the signals of Open Source Asset Pricing,
+  so sorting variables carry their names, e.g. `"size"` instead of `"me"` and
+  `"high52"` instead of `"52w"`. The examples and the documented grid values
+  follow the new release, which adds the `"1m"` lag and `"capped VW"`
+  weighting.
+
 ## New features
 
 - Added `download_data_fred_md()` and the `"FRED-MD"` / `"FRED-QD"` datasets

--- a/R/download_data.R
+++ b/R/download_data.R
@@ -78,7 +78,7 @@
 #' download_data(
 #'   "Tidy Finance",
 #'   "factor_library",
-#'   sorting_variable = "52w",
+#'   sorting_variable = "high52",
 #'   rebalancing = "annual"
 #' )
 #' download_data("Tidy Finance", "factor_library", ids = c(1L, 2L, 3L))

--- a/R/download_data_huggingface.R
+++ b/R/download_data_huggingface.R
@@ -112,44 +112,49 @@ get_available_huggingface_files <- function(organization, dataset) {
 #' Supported columns and their defaults for `...`:
 #'   \itemize{
 #'     \item `sorting_variable`: **Required.** The firm characteristic used
-#'       to sort stocks into portfolios (e.g., `"me"` for market equity,
-#'       `"bm"` for book-to-market). No default is applied.
+#'       to sort stocks into portfolios, named like the Open Source Asset
+#'       Pricing signals (e.g., `"size"` for market equity, `"bm"` for
+#'       book-to-market). See [download_factor_library_grid()] for all
+#'       values. No default is applied.
 #'     \item `min_size_quantile` (defaults to `0.2`): Fraction of the smallest
 #'       stocks (by market cap) excluded from the portfolio universe. `0.2`
 #'       drops the bottom 20%.
 #'     \item `exclude_financials` (defaults to `FALSE`): Whether to drop
-#'       financial-sector stocks (SIC 6000-6999) from the universe.
+#'       financial-sector stocks (SIC 6000-6799) from the universe.
 #'     \item `exclude_utilities` (default: `FALSE`): Whether to drop
 #'       utility-sector stocks (SIC 4900-4999) from the universe.
 #'     \item `exclude_negative_earnings` (defaults to `FALSE`): Whether to
 #'       drop firms with negative earnings before sorting.
 #'     \item `sorting_variable_lag` (defaults to `"6m"`): Lag applied to the
-#'       sorting variable before portfolio assignment (e.g., `"6m"` = 6-month
-#'       lag).
+#'       sorting variable before portfolio assignment: `"1m"` (the timing of
+#'       Open Source Asset Pricing), `"3m"`, `"6m"`, or `"ff"`
+#'       (Fama-French).
 #'     \item `rebalancing` (defaults to `"monthly"`): How frequently portfolios
 #'       are reformed: `"monthly"` or `"annual"`.
 #'     \item `n_portfolios_main` (defaults to `10`): Number of quantile groups
 #'       (e.g., `10` for decile portfolios).
 #'     \item `sorting_method` (defaults to `"univariate"`): Whether portfolios
-#'       are formed on a single sort (`"univariate"`) or a sequential double
-#'       sort (`"sequential"`).
-#'     \item `n_portfolios_secondary` (defaults to `NULL`): Number of groups
-#'       for the secondary sort variable.
+#'       are formed on a single sort (`"univariate"`) or on a double sort with
+#'       size as the second variable (`"bivariate-dependent"` or
+#'       `"bivariate-independent"`).
+#'     \item `n_portfolios_secondary` (defaults to `NULL`): Number of size
+#'       groups for the secondary sort.
 #'       Required when `sorting_method` is not `"univariate"`.
 #'     \item `breakpoints_exchanges` (defaults to: `"NYSE"`): Exchange(s) used
 #'       to compute breakpoints. `"NYSE"` uses only NYSE-listed stocks to
 #'       define quantile cutoffs (the conventional Fama-French approach).
-#'     \item `breakpoints_min_size_threshold` (defaults to `NULL`): Minimum
-#'       market-cap threshold (in USD) applied when computing breakpoints.
-#'       `NULL` means no minimum-size screen is applied.
+#'     \item `breakpoints_min_size_threshold` (defaults to `NA`): Minimum
+#'       size quantile of the stocks that set the main breakpoints (e.g.,
+#'       `0.2`). `NA` means no minimum-size screen is applied.
 #'     \item `weighting_scheme` (defaults to `"VW"`): Return weighting within
-#'       portfolios: `"VW"` for value-weighted or `"EW"` for equal-weighted.
+#'       portfolios: `"VW"` for value-weighted, `"EW"` for equal-weighted, or
+#'       `"capped VW"` for value-weighted with capped weights.
 #'   }
 #'
 #' @returns A tibble with the downloaded data. For `"high_frequency_sp500"`,
 #'   contains 5-second aggregated orderbook snapshots filtered to the requested
-#'   date range. For `"factor_library"`, contains portfolio return data joined
-#'   with the full grid metadata for the matched portfolio IDs.
+#'   date range. For `"factor_library"`, contains the columns `id`, `date`, and
+#'   `ret` joined with the full grid metadata for the matched portfolio IDs.
 #'
 #' @family download functions
 #' @export
@@ -161,15 +166,15 @@ get_available_huggingface_files <- function(organization, dataset) {
 #'   )
 #'   download_data_huggingface(
 #'     "factor_library",
-#'     sorting_variable = "52w",
+#'     sorting_variable = "high52",
 #'     rebalancing = "annual"
 #'   )
 #'   download_data_huggingface(
-#'     "factor_library", sorting_variable = "ag", fill_all = TRUE
+#'     "factor_library", sorting_variable = "assetgrowth", fill_all = TRUE
 #'   )
 #'   download_data_huggingface(
 #'     "factor_library",
-#'     sorting_variable = "me",
+#'     sorting_variable = "size",
 #'     start_date = "2000-01-01",
 #'     end_date = "2020-12-31"
 #'   )
@@ -436,12 +441,11 @@ download_factor_library_grid <- function() {
 #'
 #' Given a vector of portfolio IDs from the `tidy-finance/factor-library-grid`
 #' Hugging Face dataset, downloads the corresponding return data from the
-#' `tidy-finance/factor-library` dataset on Hugging Face. The function
-#' identifies the unique `(sorting_variable, sorting_variable_lag,
-#' sorting_method, n_portfolios_main)` combinations for the requested IDs,
-#' downloads one parquet file per combination in full, and then inner-joins
-#' to retain only the requested IDs. The grid metadata is joined back onto
-#' the result.
+#' `tidy-finance/factor-library` dataset on Hugging Face. The returns are
+#' stored in files of 1,000 consecutive IDs named after the range they cover
+#' (e.g., `id_0000001-0001000.parquet`), so the function downloads only the
+#' files that hold the requested IDs. The grid metadata is joined onto the
+#' result.
 #'
 #' Use this function when you already know the portfolio IDs you want (for
 #' example, from a previous call to [download_data_huggingface()] with
@@ -449,14 +453,17 @@ download_factor_library_grid <- function() {
 #' (sorting variable, weighting scheme, breakpoints, etc.) and download in
 #' a single call, use [download_data_huggingface()] instead.
 #'
-#' Raises an error if `ids` is empty or contains IDs that cannot be matched
-#' to a parquet file (listing the affected IDs and their key columns).
+#' Raises an error if none of the requested IDs exist in the grid. IDs whose
+#' portfolio sort failed during the construction of the library have no
+#' returns and are absent from the result. Returns are stored in single
+#' precision, and months without a valid long-short return are stored as `0`.
 #'
 #' @param ids Integer or numeric vector of portfolio IDs to download. IDs
 #'   correspond to rows of the `tidy-finance/factor-library-grid` dataset.
 #'
-#' @returns A tibble of portfolio returns with the grid metadata columns for
-#'   the requested IDs appended.
+#' @returns A tibble with the columns `id`, `date`, and `ret` (the monthly
+#'   long-short excess return) and the grid metadata columns for the
+#'   requested IDs.
 #'
 #' @family download functions
 #' @export
@@ -466,57 +473,12 @@ download_factor_library_grid <- function() {
 #'   download_factor_library_ids(c(1L, 2L, 3L))
 #' }
 download_factor_library_ids <- function(ids) {
-  organization <- "tidy-finance"
-  dataset_name <- "factor-library"
-
-  available_files <- get_available_huggingface_files(
-    organization,
-    dataset_name
-  ) |>
-    tidyr::extract(
-      col = "path",
-      into = c(
-        "sorting_variable",
-        "sorting_variable_lag",
-        "sorting_method",
-        "n_portfolios_main"
-      ),
-      regex = paste0(
-        "sorting_variable=([^/]+)/sorting_variable_lag=([^/]+)",
-        "/sorting_method=([^/]+)/n_portfolios_main=([^/]+)/"
-      ),
-      remove = FALSE
-    )
-
-  id_values <- data.frame(id = ids)
-
   id_grid <- download_factor_library_grid() |>
-    dplyr::inner_join(id_values, by = "id") |>
-    dplyr::mutate(
-      n_portfolios_main = as.character(.data$n_portfolios_main)
-    ) |>
-    dplyr::left_join(
-      available_files,
-      by = c(
-        "sorting_variable",
-        "sorting_variable_lag",
-        "sorting_method",
-        "n_portfolios_main"
-      )
-    )
+    dplyr::filter(.data$id %in% ids)
 
-  relevant_urls <- id_grid |>
-    dplyr::distinct(
-      .data$url,
-      .data$sorting_variable,
-      .data$sorting_variable_lag,
-      .data$sorting_method,
-      .data$n_portfolios_main
-    )
-
-  if (nrow(relevant_urls) == 0) {
+  if (nrow(id_grid) == 0) {
     cli::cli_abort(c(
-      "No parquet files found for the requested portfolio IDs.",
+      "None of the requested portfolio IDs exist in the factor library grid.",
       "i" = paste(
         "Check that the provided {.arg ids} are valid",
         "and exist in the factor library grid."
@@ -524,64 +486,28 @@ download_factor_library_ids <- function(ids) {
     ))
   }
 
-  missing_urls <- relevant_urls |>
-    dplyr::filter(is.na(.data$url))
+  urls <- paste0(
+    "https://huggingface.co/datasets/tidy-finance/factor-library/",
+    "resolve/main/",
+    unique(factor_library_file(id_grid$id))
+  )
 
-  if (nrow(missing_urls) > 0) {
-    missing_keys <- missing_urls |> # nolint: object_usage_linter
-      dplyr::inner_join(
-        id_grid |>
-          dplyr::select(
-            "id",
-            "sorting_variable",
-            "sorting_variable_lag",
-            "sorting_method",
-            "n_portfolios_main"
-          ),
-        by = c(
-          "sorting_variable",
-          "sorting_variable_lag",
-          "sorting_method",
-          "n_portfolios_main"
-        )
-      ) |>
-      dplyr::mutate(
-        key = paste0(
-          "id=",
-          .data$id,
-          " (",
-          .data$sorting_variable,
-          " / ",
-          .data$sorting_variable_lag,
-          " / ",
-          .data$sorting_method,
-          " / ",
-          .data$n_portfolios_main,
-          ")"
-        )
-      ) |>
-      dplyr::pull(.data$key)
+  purrr::map(urls, read_parquet_url) |>
+    dplyr::bind_rows() |>
+    dplyr::inner_join(id_grid, by = "id")
+}
 
-    cli::cli_abort(c(
-      "No parquet file found for {length(missing_keys)} portfolio ID{?s}.",
-      "x" = "Affected ID{?s}: {.val {missing_keys}}",
-      "i" = paste(
-        "Check that the {.arg sorting_variable},",
-        "{.arg sorting_variable_lag}, {.arg sorting_method},",
-        "and {.arg n_portfolios_main} values exist in the factor library."
-      )
-    ))
-  }
-
-  relevant_files <- relevant_urls$url |>
-    purrr::map(~ read_parquet_url(.x)) |>
-    dplyr::bind_rows()
-
-  relevant_files |>
-    dplyr::inner_join(
-      id_grid |> dplyr::select(-c("url", "path", "size")),
-      by = "id"
-    )
+#' Name of the factor library file that holds a portfolio ID
+#'
+#' The returns are cut into files of 1,000 consecutive IDs named after the
+#' range they cover, so the file follows from the ID alone.
+#'
+#' @param id Integer or numeric vector of portfolio IDs.
+#' @returns A character vector of file names.
+#' @noRd
+factor_library_file <- function(id) {
+  id_first <- (id - 1) %/% 1000 * 1000 + 1
+  sprintf("id_%07d-%07d.parquet", id_first, id_first + 999)
 }
 
 #' Download factor library data from Hugging Face

--- a/man/download_data.Rd
+++ b/man/download_data.Rd
@@ -96,7 +96,7 @@ download_data(
 download_data(
   "Tidy Finance",
   "factor_library",
-  sorting_variable = "52w",
+  sorting_variable = "high52",
   rebalancing = "annual"
 )
 download_data("Tidy Finance", "factor_library", ids = c(1L, 2L, 3L))

--- a/man/download_data_huggingface.Rd
+++ b/man/download_data_huggingface.Rd
@@ -45,8 +45,8 @@ columns and their defaults.}
 \value{
 A tibble with the downloaded data. For \code{"high_frequency_sp500"},
 contains 5-second aggregated orderbook snapshots filtered to the requested
-date range. For \code{"factor_library"}, contains portfolio return data joined
-with the full grid metadata for the matched portfolio IDs.
+date range. For \code{"factor_library"}, contains the columns \code{id}, \code{date}, and
+\code{ret} joined with the full grid metadata for the matched portfolio IDs.
 }
 \description{
 Downloads data from a supported Hugging Face dataset. For
@@ -66,38 +66,43 @@ design.
 Supported columns and their defaults for \code{...}:
 \itemize{
 \item \code{sorting_variable}: \strong{Required.} The firm characteristic used
-to sort stocks into portfolios (e.g., \code{"me"} for market equity,
-\code{"bm"} for book-to-market). No default is applied.
+to sort stocks into portfolios, named like the Open Source Asset
+Pricing signals (e.g., \code{"size"} for market equity, \code{"bm"} for
+book-to-market). See \code{\link[=download_factor_library_grid]{download_factor_library_grid()}} for all
+values. No default is applied.
 \item \code{min_size_quantile} (defaults to \code{0.2}): Fraction of the smallest
 stocks (by market cap) excluded from the portfolio universe. \code{0.2}
 drops the bottom 20\%.
 \item \code{exclude_financials} (defaults to \code{FALSE}): Whether to drop
-financial-sector stocks (SIC 6000-6999) from the universe.
+financial-sector stocks (SIC 6000-6799) from the universe.
 \item \code{exclude_utilities} (default: \code{FALSE}): Whether to drop
 utility-sector stocks (SIC 4900-4999) from the universe.
 \item \code{exclude_negative_earnings} (defaults to \code{FALSE}): Whether to
 drop firms with negative earnings before sorting.
 \item \code{sorting_variable_lag} (defaults to \code{"6m"}): Lag applied to the
-sorting variable before portfolio assignment (e.g., \code{"6m"} = 6-month
-lag).
+sorting variable before portfolio assignment: \code{"1m"} (the timing of
+Open Source Asset Pricing), \code{"3m"}, \code{"6m"}, or \code{"ff"}
+(Fama-French).
 \item \code{rebalancing} (defaults to \code{"monthly"}): How frequently portfolios
 are reformed: \code{"monthly"} or \code{"annual"}.
 \item \code{n_portfolios_main} (defaults to \code{10}): Number of quantile groups
 (e.g., \code{10} for decile portfolios).
 \item \code{sorting_method} (defaults to \code{"univariate"}): Whether portfolios
-are formed on a single sort (\code{"univariate"}) or a sequential double
-sort (\code{"sequential"}).
-\item \code{n_portfolios_secondary} (defaults to \code{NULL}): Number of groups
-for the secondary sort variable.
+are formed on a single sort (\code{"univariate"}) or on a double sort with
+size as the second variable (\code{"bivariate-dependent"} or
+\code{"bivariate-independent"}).
+\item \code{n_portfolios_secondary} (defaults to \code{NULL}): Number of size
+groups for the secondary sort.
 Required when \code{sorting_method} is not \code{"univariate"}.
 \item \code{breakpoints_exchanges} (defaults to: \code{"NYSE"}): Exchange(s) used
 to compute breakpoints. \code{"NYSE"} uses only NYSE-listed stocks to
 define quantile cutoffs (the conventional Fama-French approach).
-\item \code{breakpoints_min_size_threshold} (defaults to \code{NULL}): Minimum
-market-cap threshold (in USD) applied when computing breakpoints.
-\code{NULL} means no minimum-size screen is applied.
+\item \code{breakpoints_min_size_threshold} (defaults to \code{NA}): Minimum
+size quantile of the stocks that set the main breakpoints (e.g.,
+\code{0.2}). \code{NA} means no minimum-size screen is applied.
 \item \code{weighting_scheme} (defaults to \code{"VW"}): Return weighting within
-portfolios: \code{"VW"} for value-weighted or \code{"EW"} for equal-weighted.
+portfolios: \code{"VW"} for value-weighted, \code{"EW"} for equal-weighted, or
+\code{"capped VW"} for value-weighted with capped weights.
 }
 }
 \examples{
@@ -107,15 +112,15 @@ portfolios: \code{"VW"} for value-weighted or \code{"EW"} for equal-weighted.
   )
   download_data_huggingface(
     "factor_library",
-    sorting_variable = "52w",
+    sorting_variable = "high52",
     rebalancing = "annual"
   )
   download_data_huggingface(
-    "factor_library", sorting_variable = "ag", fill_all = TRUE
+    "factor_library", sorting_variable = "assetgrowth", fill_all = TRUE
   )
   download_data_huggingface(
     "factor_library",
-    sorting_variable = "me",
+    sorting_variable = "size",
     start_date = "2000-01-01",
     end_date = "2020-12-31"
   )

--- a/man/download_factor_library_ids.Rd
+++ b/man/download_factor_library_ids.Rd
@@ -11,17 +11,18 @@ download_factor_library_ids(ids)
 correspond to rows of the \code{tidy-finance/factor-library-grid} dataset.}
 }
 \value{
-A tibble of portfolio returns with the grid metadata columns for
-the requested IDs appended.
+A tibble with the columns \code{id}, \code{date}, and \code{ret} (the monthly
+long-short excess return) and the grid metadata columns for the
+requested IDs.
 }
 \description{
 Given a vector of portfolio IDs from the \code{tidy-finance/factor-library-grid}
 Hugging Face dataset, downloads the corresponding return data from the
-\code{tidy-finance/factor-library} dataset on Hugging Face. The function
-identifies the unique \verb{(sorting_variable, sorting_variable_lag, sorting_method, n_portfolios_main)} combinations for the requested IDs,
-downloads one parquet file per combination in full, and then inner-joins
-to retain only the requested IDs. The grid metadata is joined back onto
-the result.
+\code{tidy-finance/factor-library} dataset on Hugging Face. The returns are
+stored in files of 1,000 consecutive IDs named after the range they cover
+(e.g., \verb{id_0000001-0001000.parquet}), so the function downloads only the
+files that hold the requested IDs. The grid metadata is joined onto the
+result.
 }
 \details{
 Use this function when you already know the portfolio IDs you want (for
@@ -30,8 +31,10 @@ example, from a previous call to \code{\link[=download_data_huggingface]{downloa
 (sorting variable, weighting scheme, breakpoints, etc.) and download in
 a single call, use \code{\link[=download_data_huggingface]{download_data_huggingface()}} instead.
 
-Raises an error if \code{ids} is empty or contains IDs that cannot be matched
-to a parquet file (listing the affected IDs and their key columns).
+Raises an error if none of the requested IDs exist in the grid. IDs whose
+portfolio sort failed during the construction of the library have no
+returns and are absent from the result. Returns are stored in single
+precision, and months without a valid long-short return are stored as \code{0}.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-download_data_huggingface.R
+++ b/tests/testthat/test-download_data_huggingface.R
@@ -369,18 +369,21 @@ test_that("pulls url from available files and reads parquet", {
 
 # ── download_factor_library_ids ──────────────────────
 
+test_that("factor_library_file names the 1,000-id file of each id", {
+  expect_equal(
+    factor_library_file(c(1L, 1000L, 1001L, 4105728L)),
+    c(
+      "id_0000001-0001000.parquet",
+      "id_0000001-0001000.parquet",
+      "id_0001001-0002000.parquet",
+      "id_4105001-4106000.parquet"
+    )
+  )
+})
+
 test_that("aborts when no grid rows match requested ids", {
-  # make_grid(42L) has id = 42; requesting id = 999 yields an
-  # empty inner_join, so relevant_urls is empty.
   testthat::local_mocked_bindings(
-    download_factor_library_grid = function() make_grid(42L),
-    get_available_huggingface_files = function(...) {
-      tibble::tibble(
-        path = character(0),
-        size = numeric(0),
-        url = character(0)
-      )
-    }
+    download_factor_library_grid = function() make_grid(42L)
   )
 
   expect_error(
@@ -389,54 +392,40 @@ test_that("aborts when no grid rows match requested ids", {
   )
 })
 
-test_that("aborts when ids have no matching parquet file", {
-  # The available path "unrelated/data.parquet" does not match
-  # the regex in tidyr::extract, so all key columns are NA and
-  # the left_join leaves url = NA for the matched grid row.
+test_that("downloads the files that hold the ids and joins grid metadata", {
+  files <- list(
+    "id_0000001-0001000.parquet" = tibble::tibble(
+      id = c(1L, 2L),
+      date = as.Date("2020-01-01"),
+      ret = c(0.01, 0.02)
+    ),
+    "id_0001001-0002000.parquet" = tibble::tibble(
+      id = 1001L,
+      date = as.Date("2020-01-01"),
+      ret = 0.03
+    )
+  )
+  requested <- character(0)
   testthat::local_mocked_bindings(
-    download_factor_library_grid = function() make_grid(1L),
-    get_available_huggingface_files = function(...) {
-      tibble::tibble(
-        path = "unrelated/data.parquet",
-        size = 100L,
-        url = "https://example.com/unrelated/data.parquet"
-      )
+    download_factor_library_grid = function() make_grid(c(1L, 1001L)),
+    read_parquet_url = function(url) {
+      requested <<- c(requested, url)
+      files[[basename(url)]]
     }
   )
 
-  expect_error(
-    download_factor_library_ids(1L),
-    class = "rlang_error"
-  )
-})
+  result <- download_factor_library_ids(c(1L, 1001L))
 
-test_that("downloads returns and joins grid metadata", {
-  fpath <- paste0(
-    "sorting_variable=me/",
-    "sorting_variable_lag=6m/",
-    "sorting_method=univariate/",
-    "n_portfolios_main=10/",
-    "data.parquet"
+  expect_equal(
+    requested,
+    paste0(
+      "https://huggingface.co/datasets/tidy-finance/factor-library/",
+      "resolve/main/",
+      names(files)
+    )
   )
-  mock_returns <- tibble::tibble(id = 1L, ret = 0.01)
-
-  testthat::local_mocked_bindings(
-    download_factor_library_grid = function() make_grid(1L),
-    get_available_huggingface_files = function(...) {
-      tibble::tibble(
-        path = fpath,
-        size = 100L,
-        url = paste0("https://example.com/", fpath)
-      )
-    }
-  )
-  testthat::local_mocked_bindings(
-    read_parquet_url = function(...) mock_returns
-  )
-
-  result <- download_factor_library_ids(1L)
-
-  expect_true("ret" %in% names(result))
+  expect_equal(result$id, c(1L, 1001L))
+  expect_equal(result$ret, c(0.01, 0.03))
   expect_true("weighting_scheme" %in% names(result))
 })
 


### PR DESCRIPTION
## Summary

The factor library on Hugging Face moves to a normalized layout (tidy-finance/factor-library#2). The returns hold only `id`, `date`, and `ret`, in files of 1,000 consecutive ids named after their range (`id_0000001-0001000.parquet`, ...). This PR makes the package read that layout.

- `download_factor_library_ids()` computes the file of each requested id from the id alone, downloads only those files, and joins the grid. It no longer lists the files of the dataset or parses partition keys from their paths.
- The result has `id`, `date`, and `ret` plus the grid columns. `ret_type` is gone, and `weighting_scheme` from the grid carries the same information.
- The docs and examples follow the release built on Open Source Asset Pricing: sorting-variable names such as `"size"` and `"high52"`, the `"1m"` lag, the bivariate sorting methods, `"capped VW"`, the size-quantile meaning of `breakpoints_min_size_threshold`, and SIC 6000-6799 for financials, which is the range the filter uses.
- NEWS lists this under breaking changes, and the development version moves to 0.8.0.9005.

## Merge timing

Merge this together with the upload of the new returns to Hugging Face. Until then the Hub serves the old partitioned files, which this version cannot read. After the upload, earlier package versions cannot read the new files.

## Testing

- The full test suite passes locally. The `download_factor_library_ids()` tests now cover the file naming and check that exactly the files holding the requested ids are downloaded.
- An integration check ran the package against files written by the new pipeline, with a reduced grid and synthetic returns. The requested series came back with values identical to the files, only the needed files were fetched, ids without returns were absent, and `download_data("Tidy Finance", "factor_library", ...)` resolved the default filters correctly.
- nanoparquet reads the new zstd-compressed float32 files unchanged.
- lintr is not installed locally, so linting is left to CI.

## Follow-up

The README example uses `sorting_variable = "ag"` and runs against the live data, so README.Rmd and README.md are unchanged here. Once the new data is on Hugging Face, the example needs an OSAP name such as `"assetgrowth"` and the README needs re-rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
